### PR TITLE
[ADD] #20 로그인 연동 로직 변경(api추가)

### DIFF
--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/OauthService/GoogleOauthService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/OauthService/GoogleOauthService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 import trizzle.trizzlebackend.domain.User;
 
 @Service
@@ -24,6 +25,10 @@ public class GoogleOauthService {
     private String tokenUri;
     @Value("${oauth.google.resource-uri}")
     private String resourceUri;
+    @Value("${oauth.google.client-authorize}")
+    private String authorizeUri;
+    @Value("${oauth.google.scope}")
+    private String scope;
 
     public User getUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
@@ -61,5 +66,15 @@ public class GoogleOauthService {
         ResponseEntity<JsonNode> responseNode = restTemplate.exchange(tokenUri, HttpMethod.POST, httpEntity, JsonNode.class);   // <200 OK OK, {"access_token":, "expires_in":, "scope":,"token_type":, "id_token":, }, [header정보]
         JsonNode accessTokenNode = responseNode.getBody();
         return accessTokenNode.get("access_token").asText();
+    }
+
+    public String googleRedirectUri() {
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(authorizeUri)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code")
+                .queryParam("scope", scope);
+
+        return uriComponentsBuilder.toUriString();
     }
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/OauthService/KakaoOauthService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/OauthService/KakaoOauthService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 import trizzle.trizzlebackend.domain.User;
 
 @Service
@@ -22,6 +23,8 @@ public class KakaoOauthService {
     private String tokenUri;
     @Value("${oauth.kakao.resource-uri}")
     private String resourceUri;
+    @Value("${oauth.kakao.client-authorize}")
+    private String authorizeUri;
 
     public User getUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
@@ -63,5 +66,14 @@ public class KakaoOauthService {
         ResponseEntity<JsonNode> responseNode = restTemplate.exchange(tokenUri, HttpMethod.POST, httpEntity, JsonNode.class);
         JsonNode accessTokenNode = responseNode.getBody();
         return accessTokenNode.get("access_token").asText();
+    }
+
+    public String kakaoRedirectUri() {
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(authorizeUri)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code");
+
+        return uriComponentsBuilder.toUriString();
     }
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/configuration/Webconfig.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/configuration/Webconfig.java
@@ -1,0 +1,19 @@
+package trizzle.trizzlebackend.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+@Configuration
+public class Webconfig implements WebMvcConfigurer {
+    @Value("${allow.origin}")
+    private String origin;
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(origin)
+                .allowedMethods("*")
+                .allowCredentials(true)
+                .allowedHeaders("*");
+    }
+}

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/OauthController.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/OauthController.java
@@ -10,6 +10,7 @@ import trizzle.trizzlebackend.OauthService.KakaoOauthService;
 import trizzle.trizzlebackend.domain.User;
 import trizzle.trizzlebackend.service.LoginService;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -26,6 +27,20 @@ public class OauthController {
         this.loginService = loginService;
         this.googleOauthService = googleOauthService;
         this.kakaoOauthService = kakaoOauthService;
+    }
+
+    @GetMapping("/google")
+    public ResponseEntity<Void> redirectGoogle() {
+        String redirectUri = googleOauthService.googleRedirectUri();
+
+        return  ResponseEntity.status(302).location(URI.create(redirectUri)).build();
+    }
+
+    @GetMapping("/kakao")
+    public ResponseEntity<Void> redirectKakao() {
+        String redirectUri = kakaoOauthService.kakaoRedirectUri();
+
+        return ResponseEntity.status(302).location(URI.create(redirectUri)).build();
     }
 
     @GetMapping("/oauth2/code/google")  // google oauth2 redirect uri -> /login/oauth2/code/google?code={} 형식

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/domain/Plan.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/domain/Plan.java
@@ -21,7 +21,7 @@ public class Plan {
     private LocalDate plan_end_date;
     private String plan_name;
     private String plan_location;
-    private String plan_thema;
+    private List<String> plan_thema;
     private List<Day> content;
 
     public List<Day> getContent() {
@@ -56,11 +56,11 @@ public class Plan {
         this.plan_location = plan_location;
     }
 
-    public String getPlan_thema() {
+    public List<String> getPlan_thema() {
         return plan_thema;
     }
 
-    public void setPlan_thema(String plan_thema) {
+    public void setPlan_thema(List<String> plan_thema) {
         this.plan_thema = plan_thema;
     }
 


### PR DESCRIPTION
## 로그인 방식
- front에서 back의 url 접속
- 백에서 redirect해서 로그인 사이트 이동 및 front로 이동
- front에서 query parameter로 code받아서 back으로
- 이후 과정 동일

plan_thema -> List로 변경