### PR TITLE
[ADD] 유저 정보 수정 페이지 및 백엔드 api 생성

### DIFF
--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/UserContoller.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/UserContoller.java
@@ -1,17 +1,18 @@
 package trizzle.trizzlebackend.controller;
 
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.WebUtils;
 import trizzle.trizzlebackend.Utils.JwtUtil;
 import trizzle.trizzlebackend.domain.User;
 import trizzle.trizzlebackend.service.UserService;
 
+import java.util.HashMap;
+import java.util.Map;
 
 
 @RestController
@@ -41,5 +42,25 @@ public class UserContoller {
         User user = userService.searchUser(accountId);
 
         return ResponseEntity.ok().body(user);
+    };
+
+    @PutMapping("/{accountId}")
+    public ResponseEntity updateUser(@PathVariable("accountId") String accountId ,@RequestBody User user,HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        String token =authorization.split(" ")[1];
+        String account = JwtUtil.getAccountId(token, secretKey);
+        if(account.equals(accountId)) {
+            User updatedUser = userService.updateUser(user);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("message", "success");
+            response.put("updatedUser", updatedUser);
+
+            return ResponseEntity.ok().body(response);
+        }else {
+            String message = "wrong approach";
+            return ResponseEntity.ok()
+                    .body("{\"message\": \"" + message + "\"}");
+        }
     };
 };

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/UserContoller.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/UserContoller.java
@@ -1,0 +1,45 @@
+package trizzle.trizzlebackend.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.WebUtils;
+import trizzle.trizzlebackend.Utils.JwtUtil;
+import trizzle.trizzlebackend.domain.User;
+import trizzle.trizzlebackend.service.UserService;
+
+
+
+@RestController
+@RequestMapping("/user")
+public class UserContoller {
+
+    private final UserService userService;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+
+    public UserContoller(UserService userService) {
+        this.userService = userService;
+    };
+
+    @GetMapping("")
+    public ResponseEntity searchUser(HttpServletRequest request) {
+//        Cookie tokenCookie = WebUtils.getCookie(request, "accessToken");
+//        if(tokenCookie == null) return ResponseEntity.ok("로그인이 필요합니다.");
+
+//        String token = tokenCookie.getValue();
+        // 토큰 파싱
+        String authorization = request.getHeader("Authorization");
+        String token =authorization.split(" ")[1];
+        String accountId = JwtUtil.getAccountId(token, secretKey);
+        User user = userService.searchUser(accountId);
+
+        return ResponseEntity.ok().body(user);
+    };
+};

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/domain/User.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/domain/User.java
@@ -17,6 +17,8 @@ public class User {
     private String nickname;            // 회원가입 시 입력한 nickname
     private List<String> thema;
 
+    private String profileImage;
+
     public String getId() {
         return id;
     }
@@ -79,5 +81,13 @@ public class User {
 
     public void setThema(List<String> thema) {
         this.thema = thema;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+
+    public void setProfileImage(String profileImage) {
+        this.profileImage = profileImage;
     }
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/UserRepository.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package trizzle.trizzlebackend.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import trizzle.trizzlebackend.domain.User;
+
+public interface UserRepository extends MongoRepository<User, String> {
+    User findByAccountId(String accountId);
+}

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/UserService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/UserService.java
@@ -17,7 +17,10 @@ public class UserService {
     public User searchUser(String accountId) { //accountId로 유저 검색, 없으면 null return
         Optional<User> userOptional = Optional.ofNullable(userRepository.findByAccountId(accountId));
         return userOptional.orElse(null);
-    }
+    };
 
+    public User updateUser(User user) {
+        return userRepository.save(user);
+    };
 
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/UserService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/UserService.java
@@ -1,0 +1,23 @@
+package trizzle.trizzlebackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import trizzle.trizzlebackend.repository.UserRepository;
+import trizzle.trizzlebackend.domain.User;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User searchUser(String accountId) { //accountId로 유저 검색, 없으면 null return
+        Optional<User> userOptional = Optional.ofNullable(userRepository.findByAccountId(accountId));
+        return userOptional.orElse(null);
+    }
+
+
+}

--- a/trizzle-front/src/components/DropdownMenu/Dropdown.style.tsx
+++ b/trizzle-front/src/components/DropdownMenu/Dropdown.style.tsx
@@ -52,7 +52,7 @@ export const DropdownMenuItem = styled.div`
 `
 
 export const BadgeDropdownContainer = styled.div`
-  width: 90%;
+  width: 100%;
   height: auto;
   display: flex;
   flex-direction: column;
@@ -61,7 +61,8 @@ export const BadgeDropdownContainer = styled.div`
 export const BadgeDropdownInput = styled.div<{ selectedItem: boolean }>`
   display: flex;
   flex-wrap: wrap;
-  width: ${props => props.selectedItem ? "100%" : "20rem"};
+  width: ${props => props.selectedItem ? "100%" : "auto"};
+  max-width: 100%;
   height: 2.5rem;
   border: ${props => props.selectedItem ? "none" : "1px solid #9e9e9e"};
   border-radius: 0.5rem;
@@ -76,7 +77,7 @@ export const BadgeDropdownInput = styled.div<{ selectedItem: boolean }>`
   
 `
 export const BadgeDropdownMenuContainer = styled.div`
-  width: auto;
+  width: 100%;
   max-width: 65rem;
   height: auto;
   padding: 1rem 0.5rem;
@@ -87,9 +88,9 @@ export const BadgeDropdownMenuContainer = styled.div`
   border-radius: 0.5rem;
   background-color: #ffffff;
   position: absolute;
-  top: 3rem;
+  top: 5rem;
   left: 0;
-  z-index: 50;
+  z-index: 150;
 `
 
 export const BadgeDropdownMenuItem = styled.div<{ selected: boolean }>`

--- a/trizzle-front/src/pages/UserInfoEdit/UserInfoEdit.style.tsx
+++ b/trizzle-front/src/pages/UserInfoEdit/UserInfoEdit.style.tsx
@@ -1,9 +1,10 @@
 import styled from "@emotion/styled";
 
-export const Container = styled.div`
+export const Container = styled.div<{tab: string}>`
   width: 50rem;
   height: 40rem;
   max-height: 40rem;
+  position:relative;
   display: flex;
   padding: 0.6rem 2rem;
   margin: 5rem auto;
@@ -11,9 +12,7 @@ export const Container = styled.div`
   flex-direction:column;
   border: 0.1rem solid #BEBEBE;
   background-color: white;
-  overflow-y: auto;
-  ::-webkit-scrollbar {
-  }
+  overflow-y: ${props => props.tab ==="회원 정보"? "none" : "auto"} ;
 `
 
 export const TabContainer = styled.div`

--- a/trizzle-front/src/pages/UserInfoEdit/index.tsx
+++ b/trizzle-front/src/pages/UserInfoEdit/index.tsx
@@ -1,12 +1,14 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { MyfeedLayout } from "../Page";
 import * as S from "./UserInfoEdit.style"
 import Tabs from "../../components/Tabs";
 import UserInfo from "../../shared/UserInfo";
+import { useAsync } from "../../utils/API/useAsync";
 
 const UserInfoEdit = () => {
   const [tabs, setTabs] = useState([{name: "회원 정보"}, {name: "댓글 기록"}]);
   const [selectTab, setSelectTab] = useState({name: "회원 정보"});
+
 
   const onTabClick = (tab: any) => {
     setSelectTab(tab);
@@ -14,12 +16,12 @@ const UserInfoEdit = () => {
 
   return (
     <MyfeedLayout isMe={true} selectTab={{name:"내 정보", URL:"info"}}>
-      <S.Container>
+      <S.Container tab={selectTab.name}>
         <S.TabContainer>        
           <Tabs tabs={tabs} selectedTab={selectTab} onClick={(tab) => {onTabClick(tab)}}/>
         </S.TabContainer>
         {selectTab.name === "회원 정보" ? (
-          <UserInfo name="김유리" registration_id="카카오" nickname="제로콜라" account_id="yuriKim" thema={[{name: "나홀로여행", id: 8}]}/>
+          <UserInfo />
         ) : (
           <>
           </>

--- a/trizzle-front/src/shared/UserInfo/UserInfo.style.tsx
+++ b/trizzle-front/src/shared/UserInfo/UserInfo.style.tsx
@@ -34,3 +34,17 @@ export const Content = styled.div`
   word-wrap: break-word;
   padding: 0;
 `
+
+export const SubmmitButton = styled.div`
+  width: 3.5rem;
+  height: 2rem;
+  display: flex;
+  align-items:center;
+  justify-content:center;
+  cursor: pointer;
+  position: absolute;
+  top: 6rem;
+  right: 1rem;
+  border: 1px solid #929292;
+  color: #929292;
+`


### PR DESCRIPTION
## API

- user 정보 불러오기 : (get) /user
- user 정보 수정하기 : (put) /user/{accountId}
-> 현재는 프로필 이미지 변경은 불가 S3 연결 후 구현 예정

## 페이지
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/114473472/cea6a4f3-e8cf-4341-9aa7-ac7c61886738)
- 별명과 선호테마 수정 가능
- 수정하고 수정 버튼 누르면 제출
- 수정 버튼을 눌렀을 때 수정된 사항이 없으면 수정된 사항이 없다고 안내문이 뜸 (활성/비활성화로 바꿀 지 상의 후 바꿀 수 있음)