### PR TITLE
[ADD] 프로필 이미지 변경, 검색 수정

### DIFF
--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/configuration/AuthenticationConfig.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/configuration/AuthenticationConfig.java
@@ -35,7 +35,8 @@ public class AuthenticationConfig {
                                 new AntPathRequestMatcher("/v2/video"),
                                 new AntPathRequestMatcher("/upload/preSignedUrl"),
                                 new AntPathRequestMatcher("/upload/complete"),
-                                new AntPathRequestMatcher("/comments", "GET")
+                                new AntPathRequestMatcher("/comments", "GET"),
+                                new AntPathRequestMatcher("/user/header", "GET")
                         ).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtFilter(secretKey), UsernamePasswordAuthenticationFilter.class)

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/UserContoller.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/UserContoller.java
@@ -57,4 +57,30 @@ public class UserContoller {
                     .body("{\"message\": \"" + message + "\"}");
         }
     };
+
+    @PatchMapping("/profileimg")
+    public ResponseEntity updateUserProfileImg(@RequestBody String profileImg, HttpServletRequest request) {
+        String token = JwtUtil.getAccessTokenFromCookie(request);
+        String account = JwtUtil.getAccountId(token, secretKey);
+        User user = userService.patchProfileImg(profileImg, account);
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "success");
+        response.put("user", user);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/header")
+    public ResponseEntity getProfileImg(HttpServletRequest request) {
+        String token = JwtUtil.getAccessTokenFromCookie(request);
+        if(token == null || JwtUtil.isExpired(token, secretKey)) {
+            String message = "not login";
+            return ResponseEntity.ok()
+                    .body("{\"message\": \"" + message + "\"}");
+        } else {
+            String account = JwtUtil.getAccountId(token, secretKey);
+            Map<String, String> response = userService.getHeaderUserInfo(account);
+            return ResponseEntity.ok().body(response);
+        }
+    }
 };

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/UserService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/UserService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import trizzle.trizzlebackend.repository.UserRepository;
 import trizzle.trizzlebackend.domain.User;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -22,5 +24,20 @@ public class UserService {
     public User updateUser(User user) {
         return userRepository.save(user);
     };
+
+    public User patchProfileImg(String profileImg, String accountId) {
+        User user = searchUser(accountId);
+        user.setProfileImage(profileImg);
+
+        return userRepository.save(user);
+    }
+
+    public Map<String, String> getHeaderUserInfo(String accountId) {
+        User user = searchUser(accountId);
+        Map<String, String> response = new HashMap<>();
+        response.put("profileImg", user.getProfileImage());
+        response.put("id", user.getAccountId());
+        return response;
+    }
 
 }

--- a/trizzle-front/src/components/CommentInput/CommentInput.style.tsx
+++ b/trizzle-front/src/components/CommentInput/CommentInput.style.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 export const Container = styled.div`
   width: 100%;
   height: auto;
-  padding: 1rem 1.5rem;
+  padding: 1rem 0.5rem;
   display: flex;
   justify-content: flex-start;
 `
@@ -18,13 +18,11 @@ export const ContentContainer = styled.div`
 ` 
 
 export const TextArea = styled.textarea`
-  width: 64rem;
-  height: auto;
-  min-height: 1.5rem;
-  max-height: 10rem;
+  width: 66rem;
+  height: fit-content;
   word-wrap: break-word;
   border: none;
-  border-bottom: 1px solid #404040;
+  border-bottom: 1px solid #bdbdbd;
   font-size: 0.9rem;
   line-height: 1.1rem;
   font-weight: 400;

--- a/trizzle-front/src/components/CommentInput/index.tsx
+++ b/trizzle-front/src/components/CommentInput/index.tsx
@@ -1,18 +1,25 @@
-import React from "react";
+import React, {useEffect, useRef} from "react";
 import { CommentInputProps } from "./CommentInput.type";
 import * as S from "./CommentInput.style";
 import ProfileImage from "../ProfileImage";
 
 const CommentInput: React.FC<CommentInputProps> = (props: CommentInputProps) => {
-  
+    const textarea = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+      textarea.current!.style.height = "auto";
+      textarea.current!.style.height = textarea.current!.scrollHeight + "px";
+    }, [props.value]);
     return (
       <S.Container>
         <ProfileImage type="small"/>
         <S.ContentContainer>
           <S.TextArea
+            ref={textarea}
             placeholder={props.placeholder}
             value={props.value}
             onChange={props.onChange}
+            rows={2}
             />
           <S.SaveButton onClick={props.onSubmit} disabled={props.disabled}>작성</S.SaveButton>
         </S.ContentContainer>

--- a/trizzle-front/src/components/Comments/Comments.style.tsx
+++ b/trizzle-front/src/components/Comments/Comments.style.tsx
@@ -7,7 +7,7 @@ export const ParentCommentContainer = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-end;
-  margin: 0 2rem;
+  margin: 0 1.5rem;
 `
 
 export const ChildMoreButton = styled.div`

--- a/trizzle-front/src/components/Comments/Comments.type.ts
+++ b/trizzle-front/src/components/Comments/Comments.type.ts
@@ -4,7 +4,6 @@ export type CommentsProps = {
   onDelete : (id : string) => void;
   onLike : (id : string) => void;
   onFix : (id : string) => void;
-  onChild ?: () => void;
   onChildSubmit ?: (parentId:string,content : string, postId:string, reviewId:string) => void;
 };
 

--- a/trizzle-front/src/components/Comments/index.tsx
+++ b/trizzle-front/src/components/Comments/index.tsx
@@ -86,7 +86,7 @@ const Comment:React.FC<CommentsProps> = (props: CommentsProps) => {
             </S.PostCommentContentFooter>
           </S.PostCommentContent>
         </S.PostCommentContainer>
-          {childCommentOpen && 
+          {childCommentOpen &&
                   <CommentInput
                   placeholder="댓글 입력..."
                   value={value}

--- a/trizzle-front/src/components/Headers/Headers.style.tsx
+++ b/trizzle-front/src/components/Headers/Headers.style.tsx
@@ -12,7 +12,7 @@ export const Header = styled.header<{isHome:boolean}>`
   top: 0;
   left: 0;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.1);
-  z-index: 100;
+  z-index: 500;
 `
 
 export const LogoImg = styled.div`

--- a/trizzle-front/src/components/Headers/Headers.type.ts
+++ b/trizzle-front/src/components/Headers/Headers.type.ts
@@ -1,9 +1,7 @@
 export type HeadersProps = {
-  isLogin?: boolean;
   isHome?: boolean;
+  isMessage?: string;
   isRegistrationId?: string;
-  isMassage?: string;
-  isToken?: string;
   alarmCount?: number;
-  avatarSrc?: string;
+  isToken?: string;
 };

--- a/trizzle-front/src/components/Headers/index.tsx
+++ b/trizzle-front/src/components/Headers/index.tsx
@@ -4,25 +4,36 @@ import { HeadersProps } from "./Headers.type";
 import { AiOutlineBell, AiOutlinePlus } from "react-icons/ai";
 import { Link, useLocation } from "react-router-dom";
 import ProfileImage from "../ProfileImage";
-
 import logo from "../../assets/logo/Logo.svg"
 import homeLogo from "../../assets/logo/homeLogo.svg"
 import MainLogin from "../../pages/LoginPage/MainLogin";
+import { useAsync } from "../../utils/API/useAsync";
 
 const Headers: React.FC<HeadersProps> = (props: HeadersProps) => {
   let headerContent;
   const location = useLocation();
-  const isLogin = props.isLogin? props.isLogin : (props.isMassage === "login success" ? true : false);
+  const [isLogin, setIsLogin] = useState<boolean>(false);
+  const [state, fetchData] = useAsync({ url: "/api/user/header" });
   const isHome = props.isHome || false;
   const [isLoginModal, setIsLoginModal] = useState<boolean>(false);
   const [modalType, setModalType] = useState<string>('로그인');
-  const [userData, setUserData] = useState<any>({
-    token : props.isToken,
-    message : props.isMassage,
-    registrationId : props.isRegistrationId
+  const [userData, setUserData] = useState<any>({});
+  const [propsData, setPropsData] = useState<any>({
+    registrationId : props.isRegistrationId,
+    message: props.isMessage,
+    token: props.isToken
   });
+  console.log(propsData);
 
- 
+  useEffect(() => {
+    if(state.data){
+      if(state.data.message&&state.data.message==="not login") setIsLogin(false);
+      else {
+        setIsLogin(true);
+        setUserData(state.data);
+      }
+    }
+  }, [state]);
 
   if (isLogin) {
     if (location.pathname.includes('/myfeed/plans/')) {
@@ -47,8 +58,7 @@ const Headers: React.FC<HeadersProps> = (props: HeadersProps) => {
   }
 
   useEffect(() => {
-    console.log(props.isRegistrationId);
-    if (userData.message === "id 입력이 필요합니다") {
+    if (propsData.message === "id 입력이 필요합니다") {
       setIsLoginModal(!isLoginModal);
       setModalType('회원가입');
     }
@@ -80,7 +90,7 @@ const Headers: React.FC<HeadersProps> = (props: HeadersProps) => {
               )}
             </S.HeaderIconText>
             <Link to="/myfeed">
-              <ProfileImage type="small" margin="0 0 0 1.5rem" />
+              <ProfileImage type="small" margin="0 0 0 1.5rem" src={userData.profileImg}/>
             </Link>
           </S.RightWrapper>
         </S.Header>
@@ -100,7 +110,7 @@ const Headers: React.FC<HeadersProps> = (props: HeadersProps) => {
       )}
 
       {
-        isLoginModal && <MainLogin type={modalType} data={userData} onClose={(e) => setIsLoginModal(!e && !isLoginModal)} />
+        isLoginModal && <MainLogin type={modalType} data={propsData} onClose={() => setIsLoginModal(!isLoginModal)} />
       }
     </>
 

--- a/trizzle-front/src/components/KakaoMap/StaticMaps.tsx
+++ b/trizzle-front/src/components/KakaoMap/StaticMaps.tsx
@@ -14,6 +14,8 @@ const StaticMaps: React.FC<StaticMapsProps> = (props: StaticMaspProps) => {
                 // 지도의 크기
                 width: props.width,
                 height: props.height,
+                borderTopRightRadius: "1.5rem",
+                borderTopLeftRadius: "1.5rem",
             }}
             level={3} // 지도의 확대 레벨
         />

--- a/trizzle-front/src/components/PlanCard/PlanCard.style.tsx
+++ b/trizzle-front/src/components/PlanCard/PlanCard.style.tsx
@@ -19,15 +19,17 @@ export const Container = styled.div`
 export const Thumbnail = styled.div`
   width: 100%;
   height: 17.5rem;
-  border-radius: 1.5rem 1.5rem 0 0;
+  border-top-right-radius: 1.3rem;
+  border-top-left-radius: 1.3rem;
   position: relative;
 `
 
 export const ThumbnailImg = styled.img`
   width: 100%;
   height: 100%;
-  border-radius: 1.5rem 1.5rem 0 0;
-`
+  border-top-right-radius: inherit;
+  border-top-left-radius: inherit;
+  `
 
 export const NonoThumbnailContainer = styled.div`
   display: flex;

--- a/trizzle-front/src/components/ProfileImage/ProfileImage.style.tsx
+++ b/trizzle-front/src/components/ProfileImage/ProfileImage.style.tsx
@@ -56,3 +56,21 @@ export const MidCameraContainer = styled.div`
   bottom: 0.5rem;
   right: 0.5rem;
 `
+
+export const InputContainer = styled.div`
+width: 7rem;
+height: 3rem;
+
+`
+
+export const ProfileChangeInput = styled.input`
+  /* width:2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 1px solid #fff;
+  background-color: #dadada; */
+  /* position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem; */
+  display: none;
+`

--- a/trizzle-front/src/components/ProfileImage/ProfileImage.style.tsx
+++ b/trizzle-front/src/components/ProfileImage/ProfileImage.style.tsx
@@ -4,6 +4,7 @@ export const SmallContainer = styled.div<{margin?:string}>`
   width: 2.7rem;
   height: 2.7rem;
   border-radius: 50%;
+  border: 1px solid #D6D6D6;
   margin: ${({margin}) => margin? margin : "0"};
 `
 
@@ -19,6 +20,7 @@ export const MidContainer = styled.div<{margin?:string}>`
   width: 11rem;
   height: 11rem;
   border-radius: 50%;
+  border: 1px solid #D6D6D6;
   margin: ${({margin}) => margin? margin : "0"};
   position: relative;
 `

--- a/trizzle-front/src/components/ProfileImage/ProfileImage.type.ts
+++ b/trizzle-front/src/components/ProfileImage/ProfileImage.type.ts
@@ -4,4 +4,6 @@ export type ProfileImageProps = {
   type: string; // small, medium, large
   isMe?: boolean;
   margin?: string;
+  previewURL?: string;
+  setPreviewURL?: (previewURL: string) => void;
 };

--- a/trizzle-front/src/components/ProfileImage/index.tsx
+++ b/trizzle-front/src/components/ProfileImage/index.tsx
@@ -1,11 +1,107 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 import * as S from "./ProfileImage.style";
 import { ProfileImageProps } from "./ProfileImage.type";
 import { AiOutlineCamera } from "react-icons/ai";
 import avatar from "../../assets/images/default_avatar.png"
+import axios from "axios";
 
 const ProfileImage: React.FC<ProfileImageProps> = (props: ProfileImageProps) => {
   const imageSrc = props.src? props.src : avatar;
+  const [file, setFile] = useState<File | null>(null);
+
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0];
+    if (selectedFile) {
+      setFile(selectedFile);
+    }
+  };
+
+  useEffect(() => {
+    const imageHandler = async () => {
+      if(file === null) return;
+      const fileName = file.name;
+      const fileSize = file.size;
+      const url = "/api";
+
+        // 3GB가 넘어가는 파일 업로드 제한
+        if (fileSize > 3 * 1024 * 1024 * 1024) {
+          alert('The file you are trying to upload is too large. (under 3GB)');
+          return;
+        }
+  
+        try {
+          //업로드할 파일의 이름으로 Date 사용
+          let start:any = new Date();
+          //s3 관련 설정들
+          
+          let res = await axios.post(`${url}/upload/initiate`, { fileName: fileName });
+          const uploadId = res.data.uploadId;
+          const newFilename = res.data.fileName; // 서버에서 생성한 새로운 파일명
+          console.log(res);
+  
+          // 세션 스토리지에 업로드 아이디와 파일 이름을 저장합니다.
+          sessionStorage.setItem('uploadId', uploadId);
+          sessionStorage.setItem('fileName', newFilename);
+  
+          // 청크 사이즈와 파일 크기를 통해 청크 개수를 설정합니다.
+          const chunkSize = 10 * 1024 * 1024; // 10MB
+          const chunkCount = Math.floor(fileSize / chunkSize) + 1;
+          console.log(`chunkCount: ${chunkCount}`);
+  
+          let multiUploadArray = [];
+          let end:any; 
+          for (let uploadCount = 1; uploadCount < chunkCount + 1; uploadCount++) {
+            // 청크 크기에 맞게 파일을 자릅니다.
+            start = (uploadCount - 1) * chunkSize;
+            end = uploadCount * chunkSize;
+            let fileBlob = uploadCount < chunkCount ? file.slice(start, end) : file.slice(start);
+  
+            // 3. Spring Boot 서버로 Part 업로드를 위한 미리 서명된 URL 발급 바듭니다.
+            let getSignedUrlRes = await axios.post(`${url}/upload/preSignedUrl`, {
+              fileName: newFilename,
+              partNumber: uploadCount,
+              uploadId: uploadId
+            });
+  
+            let preSignedUrl = getSignedUrlRes.data.preSignedUrl;
+            console.log(`preSignedUrl ${uploadCount} : ${preSignedUrl}`);
+            console.log(fileBlob);
+  
+            // 3번에서 받은 미리 서명된 URL과 PUT을 사용해 AWS 서버에 청크를 업로드합니다,
+            let uploadChunck = await axios.put(preSignedUrl, fileBlob);
+            console.log(uploadChunck);
+            // 응답 헤더에 있는 Etag와 파트 번호를 가지고 있습니다.
+            if(uploadChunck.headers.get('ETag') === null) throw new Error("ETag is null");
+            let EtagHeader = uploadChunck.headers.get('ETag').replaceAll('\"', '');
+            console.log(EtagHeader);
+            let uploadPartDetails = {
+              awsETag: EtagHeader,
+              partNumber: uploadCount
+            };
+  
+            multiUploadArray.push(uploadPartDetails);
+          }
+  
+          console.log(multiUploadArray);
+          // 6. 모든 청크 업로드가 완료되면 Spring Boot 서버로 업로드 완료 요청을 보냅니다.
+          // 업로드 아이디 뿐만 아니라 이 때 Part 번호와 이에 해당하는 Etag를 가진 'parts'를 같이 보냅니다.
+          const completeUpload = await axios.post(`${url}/upload/complete`, {
+            fileName: newFilename,
+            parts: multiUploadArray,
+            uploadId: uploadId
+          });
+          end = new Date();
+          console.log("파일 업로드 하는데 걸린 시간 : " + (end - start) + "ms")
+          props.setPreviewURL(completeUpload.data.url);
+          console.log(completeUpload.data.url, ' 업로드 완료 응답값');
+        } catch (err:any) {
+          console.log(err, err.stack);
+        }
+    };
+
+    imageHandler();
+  }, [file]);
 
   if(props.type === "big") {
     return (
@@ -23,8 +119,17 @@ const ProfileImage: React.FC<ProfileImageProps> = (props: ProfileImageProps) => 
   } else if(props.type === "mid"){
     return (
     <S.MidContainer margin={props.margin}>
-      <S.ProfileImage src={imageSrc} alt="profile" />
-      {props.isMe===true && <S.MidCameraContainer><AiOutlineCamera color="#fff" size="1rem"/></S.MidCameraContainer>}
+      <S.ProfileImage src={props.previewURL === null ? imageSrc : props.previewURL} alt="profile" />
+      {props.isMe===true && 
+      <>
+      <label htmlFor="file">
+        <S.MidCameraContainer>
+          <AiOutlineCamera color="#fff" size="1.5rem"/>
+        </S.MidCameraContainer>
+        </label>
+        <S.ProfileChangeInput id="file" type="file" accept="image/*" onChange={handleFileChange}/>
+      </>
+      }
   </S.MidContainer>
     )
   }

--- a/trizzle-front/src/components/ProfileImage/index.tsx
+++ b/trizzle-front/src/components/ProfileImage/index.tsx
@@ -6,7 +6,7 @@ import avatar from "../../assets/images/default_avatar.png"
 
 const ProfileImage: React.FC<ProfileImageProps> = (props: ProfileImageProps) => {
   const imageSrc = props.src? props.src : avatar;
-  console.log(props.isMe);
+
   if(props.type === "big") {
     return (
       <S.BigContainer margin={props.margin}>

--- a/trizzle-front/src/components/SearchBar/SearchBar.style.tsx
+++ b/trizzle-front/src/components/SearchBar/SearchBar.style.tsx
@@ -4,27 +4,50 @@ import styled from "@emotion/styled";
 export const Container = styled.div<{type:string}>`
   width: 100%;
   height: 5rem;
-  background-color: ${({type}) => type === "main" ? "#EBB700" : "white"};
+  background-color: ${({type}) => type === "main" ? "#ffff" : "#EBB700"};
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
+  position: ${({type}) => type === "main" ? "relative" : "fixed"};
   padding: 0 8rem;
+  top:4.5rem;
+  left:0;
+  z-index: ${({type}) => type === "main" ? "100" : "100"};
 `
 
 export const InputContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 98%;
+  width: 100%;
   height: 3.5rem;
   border: 2px solid #EBB700;
   background-color: #ffffff;
+  border-radius: 0.75rem;
+  position: relative;
+  z-index: 100;
+  .searchIcon {
+    width: 1.7rem;
+    height: 1.7rem;
+    margin-right: 1rem;
+    color: #bdbdbd;
+    cursor: pointer; 
+    &:hover {
+      color: #EBB700;
+    }
+  }
 `
 
-export const InputValueContainer = styled.div`
+export const InputValueContainer = styled.input`
+  width: fit-content;
+  height: 100%;
   margin: 0 0 0 1rem;
   font-size: 1.2rem;
+  border:none;
+  &:focus {
+    outline: none;
+    border: none;
+  }
 `
 
 export const HorizontalFirstStartContainer = styled.div`
@@ -35,7 +58,7 @@ export const HorizontalFirstStartContainer = styled.div`
 
 // 일정, 장소 검색 대상 결정 컴포넌트
 export const DropdownContainer = styled.div`
-  width: 6rem;
+  width: auto;
   height: 100%;
   display: flex;
   align-items: center;
@@ -87,15 +110,15 @@ export const OptionButton = styled.div`
 `
 
 // 위치 입력 컴포넌트
-export const PlaceOptionContainer = styled.div`
+export const PlaceOptionContainer = styled.div<{type?:string}>`
   width: 40rem;
   height: 10rem;
   border: 2px solid #EBB700;
   background-color: #ffffff;
   overflow-y: scroll;
   position: absolute;
-  top: 5rem;
-  left: 19rem;
+  top: 4rem;
+  left: 0;
 `
 
 export const PlaceOptionButton = styled.div`
@@ -122,7 +145,7 @@ export const PlaceSubOptionContainer = styled.div`
   overflow-y: scroll;
   position: absolute;
   top: 5rem;
-  left: 50rem;
+  left: 8rem;
 `
 
 export const PlaceSubOptionButton = styled.div`

--- a/trizzle-front/src/components/SearchBar/SearchBar.type.ts
+++ b/trizzle-front/src/components/SearchBar/SearchBar.type.ts
@@ -1,0 +1,5 @@
+export type SearchBarProps = {
+  type: string;
+  value?: string;
+  region?: string;
+};

--- a/trizzle-front/src/components/SearchBar/index.tsx
+++ b/trizzle-front/src/components/SearchBar/index.tsx
@@ -1,64 +1,42 @@
 import React, { useEffect, useState } from "react";
 import * as S from './SearchBar.style'
+import { SearchBarProps } from "./SearchBar.type";
 import { BsMap } from 'react-icons/bs';
-import { BiSolidDownArrow } from 'react-icons/bi';
+import { IoIosSearch } from "react-icons/io";
 import { koreaRegions } from '../../utils/Data/mapData';
+import { useNavigate } from "react-router-dom";
 
-export default function SearchBar(type?:any) {
-  const [searchField, setSearchField] = useState<string>('일정');
-  const [searchValue, setSearchValue] = useState<string>('');
+const SearchBar:React.FC<SearchBarProps> = (props: SearchBarProps) => {
+  const [searchField, setSearchField] = useState<string>(props.region? props.region: "전체");
+  const [searchValue, setSearchValue] = useState<string>(props.value? props.value: '');
   const [isFieldOpen, setIsFieldOpen] = useState<boolean>(false);
   const [isMapOpen, setIsMapOpen] = useState<boolean>(false);
   const [isHovered, setIsHovered] = useState(false);
+  const navigate = useNavigate();
 
-  const onClick = (value: string) => {
-    setIsFieldOpen(!isFieldOpen);
-    setSearchField(value);
-    setSearchValue(searchValue);
+  const onSearch = () => {
+    if(searchValue !== '') { 
+      navigate(`/search/${searchField}/plans?keyword=${searchValue}`);
+    }
   }
 
-  // const handleKeyPress = (e) => {
-  //   if (e.key === 'Enter') {
-  //     onFieldDate(searchField);
-  //     onValueData(searchValue);
-  //   }
-  // };
-
-  const isMapClose = (region: string) => {
-    setIsMapOpen(!isMapOpen);
-    setSearchValue((prev) => prev + ` ${region}`);
-  }
+  const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if(e.key === "Enter") {
+      onSearch();
+    }
+  };
 
   return (
-    <S.Container type={type? type: "normal"}>
+    <S.Container type={props.type? props.type: "normal"}>
       <S.InputContainer>
         <S.HorizontalFirstStartContainer>
           <S.DropdownContainer>
             <S.DropdownButton type="button" onClick={() => setIsFieldOpen(!isFieldOpen)}>
               {searchField}
-              <BiSolidDownArrow size="0.8rem" />
-            </S.DropdownButton>
-            {isFieldOpen &&
-              <S.OptionContainer>
-                <S.OptionButton onClick={() => onClick("일정")} >
-                  일정
-                </S.OptionButton>
-                <S.OptionButton onClick={() => onClick("장소")} >
-                  장소
-                </S.OptionButton>
-              </S.OptionContainer>
-            }
-          </S.DropdownContainer>
-
-          <S.InputValueContainer>
-            {searchValue}
-          </S.InputValueContainer>
-        </S.HorizontalFirstStartContainer>
-
-        <BsMap
+              <BsMap
           style={{
-            width: "4rem",
-            height: "2rem",
+            width: "3rem",
+            height: "1.5rem",
             color: isHovered || isMapOpen ? "#FFDC61" : "#D9D9D9",
             opacity: 0.8
           }}
@@ -66,25 +44,30 @@ export default function SearchBar(type?:any) {
           onMouseLeave={() => setIsHovered(false)}
           onClick={() => setIsMapOpen(!isMapOpen)}
         />
-        {isMapOpen && (
-          <S.PlaceOptionContainer>
-            {koreaRegions.map((place, index) => (
-              <S.PlaceOptionButton key={index} onClick={() => setSearchValue(place.name)} >
-                {place.name}
-              </S.PlaceOptionButton>
-            ))}
-          </S.PlaceOptionContainer>
-        )}
-        {/* {isMapOpen && searchValue != '' && (
-          <S.PlaceSubOptionContainer>
-            {koreaRegions.map((place, index) => (
-              <S.PlaceSubOptionButton key={index} onClick={() => isMapClose(place.name)} >
-                {place.name}
-              </S.PlaceSubOptionButton>
-            ))}
-          </S.PlaceSubOptionContainer>
-        )} */}
+            </S.DropdownButton>
+            {isFieldOpen &&
+              <S.PlaceOptionContainer type={props.type? props.type: "normal"}>
+              {koreaRegions.map((place, index) => (
+                <S.PlaceOptionButton key={index} onClick={() => setSearchField(place.name)} >
+                  {place.name}
+                </S.PlaceOptionButton>
+              ))}
+            </S.PlaceOptionContainer>
+            }
+          </S.DropdownContainer>
+
+          <S.InputValueContainer
+            placeholder="검색어를 입려해주세요"
+            type="text"
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+            onKeyDown={onKeyPress}
+          />
+        </S.HorizontalFirstStartContainer>
+        <IoIosSearch className="searchIcon" onClick={onSearch}/>
       </S.InputContainer>
     </S.Container>
   )
 }
+
+export default SearchBar;

--- a/trizzle-front/src/components/Tabs/Tabs.style.tsx
+++ b/trizzle-front/src/components/Tabs/Tabs.style.tsx
@@ -22,3 +22,32 @@ export const Tab = styled.div<{active: boolean}>`
   color: ${({active}) => active ? "#000000" : "#BDBDBD"};
   border-bottom: ${({active}) => active ? "2px solid #000" : "2px solid #dadada"};
 `
+
+export const RoundTabContainer = styled.div`
+  width: 100%;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  margin: 8rem 0 3rem 0;
+`
+
+export const RoundTab = styled.div<{active: boolean}>`
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  display: flex;
+  border-radius: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 1rem;
+  font-weight: ${({active}) => active ? "600" : "400"};
+  color: ${({active}) => !active ? "#bdbdbd" : "#EBB700"};
+  border: ${({active}) => !active ? "1px solid #bdbdbd" : "2px solid #EBB700"};
+  cursor: pointer;
+  .icon {
+    color: ${({active}) => !active ? "#bdbdbd" : "#EBB700"};
+    margin-right: 0.5rem;
+  }
+`

--- a/trizzle-front/src/components/Tabs/Tabs.type.ts
+++ b/trizzle-front/src/components/Tabs/Tabs.type.ts
@@ -1,4 +1,5 @@
 export type TabsProps = {
+  type?: string;
   tabs: any[];
   selectedTab: any;
   onClick: (tab: string) => void;

--- a/trizzle-front/src/components/Tabs/index.tsx
+++ b/trizzle-front/src/components/Tabs/index.tsx
@@ -1,8 +1,23 @@
 import React from "react";
 import * as S from "./Tabs.style";
 import { TabsProps } from "./Tabs.type";
+import { FaMapSigns } from "react-icons/fa";
+import { BsPinMapFill } from "react-icons/bs";
 
 const Tabs: React.FC<TabsProps> = (props: TabsProps) => {
+
+  if(props.type === "roundButton") {
+    return (
+      <S.RoundTabContainer>
+        {props.tabs.map((tab, index) => (
+          <S.RoundTab key={index} onClick={() => props.onClick(tab)} active={props.selectedTab.name === tab.name}>
+            {tab.name === "일정" ? <><FaMapSigns size="1.1rem" className="icon"/> 일정</>: <><BsPinMapFill size="1.1rem"  className="icon"/>리뷰</>}
+          </S.RoundTab>
+        )
+        )}
+      </S.RoundTabContainer>
+    )
+  }else {
   return (
     <S.TabContainer>
       {props.tabs.map((tab, index) => (
@@ -11,6 +26,7 @@ const Tabs: React.FC<TabsProps> = (props: TabsProps) => {
       )}
     </S.TabContainer>
   )
+  };
 };
 
 export default Tabs;

--- a/trizzle-front/src/pages/Home/index.tsx
+++ b/trizzle-front/src/pages/Home/index.tsx
@@ -7,6 +7,7 @@ import SearchBar from "../../components/SearchBar";
 import FestivalCard from "../../shared/FestivalCard";
 import HorizontalScrollContainer from "../../components/HorizontalScrollComponent";
 import Paging from "../../components/Paging";
+import CommentSection from "../../shared/CommentSection";
 
 
 
@@ -47,7 +48,6 @@ const PlanCardLists = [
 ];
 
 const Home = () => {
-  const [isLogin, setIsLogin] = useState<boolean>(false);
   const [registrationId, setRegistrationId] = useState<string>('');
   const [message, setMessage] = useState<string>('');
   const [token, setToken] = useState<string>('');
@@ -77,20 +77,17 @@ const Home = () => {
 
   }, []);
 
-  console.log(festivalLists);
   return (
     <>
       {registrationId && message && token && (
         <Page
           headersProps={{
-            isLogin: isLogin,
             isHome: true,
             isRegistrationId: registrationId,
-            isMassage: message,
+            isMessage: message,
             isToken: token,
           }}
         >
-          <div style={{marginBottom:"5rem"}}/>
           <SearchBar type="main"/>
           <S.SectionTitle>급상승! 현재 인기 일정 <b style={{fontWeight:"500"}}>&nbsp;TOP </b><p style={{color:"red"}}>&nbsp;4</p></S.SectionTitle>
           <HomePlanSlider planList={PlanLists} />

--- a/trizzle-front/src/pages/Page/Page.style.tsx
+++ b/trizzle-front/src/pages/Page/Page.style.tsx
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+
+export const SearchContainer = styled.div`
+  margin: '0 0 0 2rem';
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  color: #747474;
+  font-size: 2rem;
+  font-weight: 400;
+`
+
+export const SearchText = styled.div`
+  color: #747474;
+  font-weight: 700;
+`

--- a/trizzle-front/src/pages/Page/index.tsx
+++ b/trizzle-front/src/pages/Page/index.tsx
@@ -1,10 +1,13 @@
 import Headers from "../../components/Headers";
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
 import { HeadersProps } from "../../components/Headers/Headers.type";
 import Footer from "../../components/Footers";
 import styled from "@emotion/styled";
 import Tabs from "../../components/Tabs";
-import { useNavigate } from "react-router-dom";
+import * as S from "./Page.style";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { koreaRegions } from "../../utils/Data/mapData";
+import SearchBar from "../../components/SearchBar";
 
 type PageProps = {
   headersProps: HeadersProps;
@@ -51,15 +54,66 @@ export const MyfeedLayout: React.FC<{children: React.ReactNode, isMe:boolean, se
   return (
     <>
     {isMe ? (
-      <Page headersProps={{isLogin: true, isHome: false}}>
+      <Page headersProps={{isHome: false}}>
       <Tabs tabs={tabs} selectedTab={tab} onClick={(tab) => {onTabClick(tab)}}/>
       {children}
     </Page>
     ) : (
-      <Page headersProps={{isLogin: true, isHome: false}}>
+      <Page headersProps={{isHome: false}}>
         {children}
       </Page>
     )}
     </>
   )
+};
+
+export const SearchLayout:React.FC<{children: React.ReactNode, selectTab:any}> = ({children, selectTab}) => {
+  const {region} = useParams<any>();
+  const {search} = useLocation();
+  const navigate = useNavigate();
+  const keyword = decodeURI(search.split('=')[1]);
+  const tabList = [{name: "일정", URL:`/search/${region}/plans${search}`}, {name:"장소", URL:`/search/${region}/places${search}`}]
+  const [reg, setRegion] = useState<any>(koreaRegions[0]);
+  const [tabs, setTabs] = useState<any[]>(tabList);
+  const [tab, setTab] = useState<any>(tabList.filter((tab) => tab.name === selectTab)[0]);
+  useEffect(() => {
+    if(region !== "전체") {
+      setRegion(koreaRegions.filter((region) => reg.name === region)[0]);
+    }
+  },[]);
+
+  const onTabClick = (tab:any) => {
+    setTab(tab);
+    navigate(`${tab.URL}`);
+  };
+
+  if(tabs.length !== 0) {
+  return (
+    <Page headersProps={{ isHome: false }}>
+      <SearchBar type="normal" value={keyword} region={region}/>
+      <Tabs type="roundButton" tabs={tabs} selectedTab={tab} onClick={(tab) => {onTabClick(tab)}}/>
+      {/* {plan !== "전체" && (
+      <S.RegionContainer>
+        <Maps center={region.center} type="infor" />
+        <S.RegionInforContainer>
+          <S.RegionName>{regionInformation.region}</S.RegionName>
+          <S.RegionInfor>{regionInformation.information}</S.RegionInfor>
+        </S.RegionInforContainer>
+      </S.RegionContainer>
+      )} */}
+        <S.SearchContainer>
+          <S.SearchText>
+            {region}
+          </S.SearchText>
+        에 대한 검색 결과입니다.
+      </S.SearchContainer>
+        {children}
+      </Page>
+  )} else {
+    return (
+      <Page headersProps={{ isHome: false }}>
+        {children}
+      </Page>
+    )
+  }
 }

--- a/trizzle-front/src/pages/SearchPlace/SearchPlace.styles.tsx
+++ b/trizzle-front/src/pages/SearchPlace/SearchPlace.styles.tsx
@@ -5,7 +5,7 @@ export const RegionContainer = styled.div`
   justify-content: flex-start;
   align-items: flex-start;
   gap: 2rem;
-  margin: 2rem 0 2rem 0;
+  margin: 7rem 0 2rem 0;
 `
 
 export const RegionInforContainer = styled.div`

--- a/trizzle-front/src/pages/SearchPlace/SearchPlace.tsx
+++ b/trizzle-front/src/pages/SearchPlace/SearchPlace.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-
+import { useParams } from "react-router-dom";
+import { koreaRegions } from "../../utils/Data/mapData";
 import * as S from './SearchPlace.styles';
-import Page from "../Page";
+import {SearchLayout} from "../Page";
 import Maps from "../../components/KakaoMap";
 import PlaceCard from "../../components/PlaceCard";
-import img from 'C:/Users/ajtwo/OneDrive/바탕 화면/image19.png'
+import img from '../../assets/images/default_festival.jpg'
 import SearchBar from "../../components/SearchBar";
 
 const regionInformation = {
@@ -103,26 +104,8 @@ const placeSample = [{
 }]
 
 const SearchPlace = () => {
-  const [region, useResgion] = useState<any>({ lat: 37.5665, lng: 126.9780 })
-
   return (
-    <Page headersProps={{ isHome: false, isLogin: true }}>
-      <SearchBar />
-      <S.RegionContainer>
-        <Maps center={region} type="infor" />
-        <S.RegionInforContainer>
-          <S.RegionName>{regionInformation.region}</S.RegionName>
-          <S.RegionInfor>{regionInformation.information}</S.RegionInfor>
-        </S.RegionInforContainer>
-      </S.RegionContainer>
-
-      <S.SearchContainer>
-        <S.SearchText>
-          &#123; 검색결과 &#125;
-        </S.SearchText>
-        에 대한 다른 장소 추천 결과 입니다.
-      </S.SearchContainer>
-
+    <SearchLayout selectTab="장소">
       <S.SearchResultContainer>
         {placeSample.map((place, index) => (
           <S.PlaceCardContainer key={index}>
@@ -130,7 +113,7 @@ const SearchPlace = () => {
           </S.PlaceCardContainer>
         ))}
       </S.SearchResultContainer>
-    </Page>
+    </SearchLayout>
   )
 }
 

--- a/trizzle-front/src/pages/SearchPlan/SearchPlan.styles.tsx
+++ b/trizzle-front/src/pages/SearchPlan/SearchPlan.styles.tsx
@@ -5,7 +5,7 @@ export const RegionContainer = styled.div`
   justify-content: flex-start;
   align-items: flex-start;
   gap: 2rem;
-  margin: 2rem 0 2rem 0;
+  margin: 7rem 0 2rem 0;
 `
 
 export const RegionInforContainer = styled.div`
@@ -28,22 +28,6 @@ export const RegionInfor = styled.div`
   font-size: 1.2rem;
   font-weight: 400;
   line-height: 1.7rem;
-`
-
-export const SearchContainer = styled.div`
-  margin: 2rem 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  color: #747474;
-  font-size: 2rem;
-  font-weight: 400;
-`
-
-export const SearchText = styled.div`
-  color: #747474;
-  font-weight: 700;
 `
 
 export const SearchResultContainer = styled.div`

--- a/trizzle-front/src/pages/SearchPlan/SearchPlan.tsx
+++ b/trizzle-front/src/pages/SearchPlan/SearchPlan.tsx
@@ -1,14 +1,14 @@
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import * as S from './SearchPlan.styles';
-import Page from "../Page";
+import {SearchLayout} from "../Page";
 import Maps from "../../components/KakaoMap";
 import img from '../../assets/images/default_festival.jpg'
 import SearchBar from "../../components/SearchBar";
 import PlanCard from "../../components/PlanCard";
 import { koreaRegions } from "../../utils/Data/mapData";
-import { useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 
 const regionInformation = {
   region: "서울특별시",
@@ -162,28 +162,10 @@ const planContainer = [{
 
 
 const SearchPlan = () => {
-  const {plan} = useParams<any>();
-  const [region, setResgion] = useState<any>(koreaRegions.filter((region) => region.name === plan)[0]);
   const [planList, setPlanList] = useState<any>(planContainer);
 
   return (
-    <Page headersProps={{ isHome: false, isLogin: true }}>
-      <SearchBar type="normal"/>
-      <S.RegionContainer>
-        <Maps center={region.center} type="infor" />
-        <S.RegionInforContainer>
-          <S.RegionName>{regionInformation.region}</S.RegionName>
-          <S.RegionInfor>{regionInformation.information}</S.RegionInfor>
-        </S.RegionInforContainer>
-      </S.RegionContainer>
-
-      <S.SearchContainer>
-        <S.SearchText>
-          {region.name}
-        </S.SearchText>
-        에 대한 일정 검색 결과입니다.
-      </S.SearchContainer>
-
+    <SearchLayout selectTab="일정" >
       <S.SearchResultContainer>
         <S.PlanCardContainer>
           {planList.map((plan:any, index:number) => (
@@ -202,7 +184,7 @@ const SearchPlan = () => {
           ))}
         </S.PlanCardContainer>
       </S.SearchResultContainer>
-    </Page>
+    </SearchLayout>
   )
 }
 

--- a/trizzle-front/src/route/index.tsx
+++ b/trizzle-front/src/route/index.tsx
@@ -27,10 +27,10 @@ const Router = () => {
         <Route path="/mypage/plans/add" element={<AddPlanPage />} />
         <Route path="/mypage/plans/edit/:id" element={<EditPlanPage />} />
 
-        <Route path='/Search/:place/places' element={<SearchPlace />} />
-        <Route path='/Search/:plan/plans' element={<SearchPlan />} />
+        <Route path='/search/:region/places' element={<SearchPlace />} />
+        <Route path='/search/:region/plans' element={<SearchPlan />} />
 
-        <Route path='post/plans/add' element={<AddPostPlan />} />
+        <Route path='/post/plans/add' element={<AddPostPlan />} />
         <Route path='/post/plan/:id' element={<PostPlan />} />
 
         <Route path="/post/places/:id" element={<PostPlace />} />

--- a/trizzle-front/src/shared/HomePlanSlider/index.tsx
+++ b/trizzle-front/src/shared/HomePlanSlider/index.tsx
@@ -11,7 +11,7 @@ const HomePlanSlider: React.FC<HomePlanSliderProps> = (props: HomePlanSliderProp
   useEffect(() => {
     const timer = setInterval(() => {
       setCurrentPlan((prev) =>(prev+1)%4);
-    }, 7000);
+    }, 5000);
 
     return () => {
       clearInterval(timer);
@@ -19,7 +19,6 @@ const HomePlanSlider: React.FC<HomePlanSliderProps> = (props: HomePlanSliderProp
 
 
   }, [currentPlan]);
-  console.log(currentPlan);
 
   return (
       <S.Wrapper >

--- a/trizzle-front/src/shared/UserInfo/index.tsx
+++ b/trizzle-front/src/shared/UserInfo/index.tsx
@@ -54,11 +54,10 @@ const UserInfo = () => {
     thema.map((thema) => {
       themaNames.push(thema.name);
     });
-    console.log(themaNames, userData?.thema);
-    if(nickname === userData?.nickname && userData?.thema === themaNames) {
-      setAbleSubmit(false);
-    } else {
+    if(nickname !== userData?.nickname || JSON.stringify(userData?.thema.sort()) !== JSON.stringify(themaNames.sort())) {
       setAbleSubmit(true);
+    } else {
+      setAbleSubmit(false);
     }
   }, [nickname, thema]);
 
@@ -85,7 +84,7 @@ const UserInfo = () => {
     thema.map((thema) => {
       themaNames.push(thema.name);
     });
-    if(userData !== undefined && userData.nickname !== nickname && userData.thema !== themaNames) {
+    if(userData !== undefined) {
       if(confirm("수정사항을 저장하시겠습니까?")) {
       const submitData = {
         accountId : userData.accountId,
@@ -102,8 +101,6 @@ const UserInfo = () => {
     } else {
       return;
     }
-  }else {
-    alert("수정된 사항이 없습니다");
   }
   }
 

--- a/trizzle-front/src/shared/UserInfo/index.tsx
+++ b/trizzle-front/src/shared/UserInfo/index.tsx
@@ -24,6 +24,7 @@ const UserInfo = () => {
   const [thema, setThema] = useState<{name:string, id:number}[]>([]);
   const [state, fetchData] = useAsync({url:"/api/user"});
   const [ableSubmit, setAbleSubmit] = useState<boolean>(false);
+  const [previewURL, setPreviewURL] = useState<string>("");
 
   useEffect(() => {
     if(state.error) console.error(state.error);
@@ -35,6 +36,7 @@ const UserInfo = () => {
 
       setUserData(data);
       setNickname(data.nickname);
+      setPreviewURL(data.profileImage)
       setThema(data.thema.map((it:any) => {
         const thema = tripThema.filter((item) => {
           return item.name === it
@@ -54,12 +56,12 @@ const UserInfo = () => {
     thema.map((thema) => {
       themaNames.push(thema.name);
     });
-    if(nickname !== userData?.nickname || JSON.stringify(userData?.thema.sort()) !== JSON.stringify(themaNames.sort())) {
+    if(nickname !== userData?.nickname || JSON.stringify(userData?.thema.sort()) !== JSON.stringify(themaNames.sort()) || previewURL !== userData?.profileImage) {
       setAbleSubmit(true);
     } else {
       setAbleSubmit(false);
     }
-  }, [nickname, thema]);
+  }, [nickname, thema, previewURL]);
 
   const handleInputChange = (event: any) => {
     // 입력 값 업데이트
@@ -92,7 +94,7 @@ const UserInfo = () => {
         id: userData.id,
         name : userData.name,
         nickname: nickname,
-        profileImage : userData.profileImage,
+        profileImage : previewURL,
         registrationId : userData.registrationId,
         socialId : userData.socialId,
         thema : themaNames
@@ -108,7 +110,7 @@ const UserInfo = () => {
   return (
     <S.Container>
       <S.SubmmitButton onClick={onUpdateData} disabled={!ableSubmit}>저장</S.SubmmitButton>
-      <ProfileImage type="mid" isMe={true} margin="0 auto 0.5rem auto"/>
+      <ProfileImage type="mid" isMe={true} margin="0 auto 0.5rem auto" previewURL={previewURL} setPreviewURL={(previewURL:string) => setPreviewURL(previewURL)}/>
       <S.HorizontalContainer>
         <S.Title>이름</S.Title>
         <S.Content>{userData.name}</S.Content>


### PR DESCRIPTION
## 프로필 이미지 변경

- S3에 올리고 url 받아서 백으로 보냄
- 변경되어 DB에 저장된 모습
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/114473472/d90e7b74-8861-4e5d-9df3-fc04e9eebe7b)
- 변경되어 헤더에 나타난 모습
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/114473472/7257b762-dccc-42ef-8a6f-0adc0406b226)
- 프로필 수정에서 변경 가능

## 검색 수정
- 기존에 일정/장소 선택에서 장소 선택만 넣음
- 기존에 input없었던 부분에 input을 넣어 입력을 받을 수 있도록 함
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/114473472/680fbd02-82c6-4d84-87a2-54de7d2b4d7e)
- 검색하면 일정/리뷰 탭이 나타남(기본은 일정 탭)
- url 전략은 아래 캡쳐본과 같고 기존에 Search/:plan과 /Search/:place로 나뉘어 있던 걸 /search/:region으로 변경하고 공통의 레이아웃을 만듦
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/114473472/d780bcdd-e2d6-41d4-b737-cf4e0b21e5f1)


##To-do

- [ ] 검색 결과 정렬, 필터 추가
- [ ] 검색 결과 백엔드 연동


