### PR TITLE
[ADD] 일정 게시글 내 장소-리뷰 연동 시 새 리뷰 작성 기능 추가

### DIFF
--- a/trizzle-front/src/components/PlanCard/index.tsx
+++ b/trizzle-front/src/components/PlanCard/index.tsx
@@ -11,7 +11,7 @@ const PlanCard: React.FC<PlanCardProps> = (props: PlanCardProps) => {
     props.thema.splice(3, props.thema.length - 3);
   }
   return (
-    <Link to={`/post/plans/${props.planId}`}>
+    <Link to={`/post/plan/${props.planId}`}>
       <S.Container>
         <S.Thumbnail >
           {props.thumbnail === "" ?  <StaticMaps center={props.region} width="100%" height="17.5rem" /> : <S.ThumbnailImg src={props.thumbnail} />}

--- a/trizzle-front/src/pages/AddPlace/ConnectPlace.tsx
+++ b/trizzle-front/src/pages/AddPlace/ConnectPlace.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import Page from "../Page";
 import * as S from "./AddPlace.styles";
 import TextInput from "../../components/TextInput";
@@ -11,6 +11,7 @@ import { useAsync } from "../../utils/API/useAsync";
 import { koreaRegions } from "../../utils/Data/mapData";
 
 export default function ConnectPlace() {
+  const path = window.location.pathname;
   const planInfor = useParams<{ planDay: string, planId: string, placeId: string }>();
   const [state, fetchData] = useAsync({ url: `/api/plans/${planInfor.planId}` });
   const [planData, setPlanData] = useState<any>({});
@@ -25,6 +26,14 @@ export default function ConnectPlace() {
   const region: any = koreaRegions[0];
   const [representImage, setRepresentImage] = useState<string>(''); // 대표이미지
   const [resultData, setResultData] = useState<any>({});
+
+  useEffect(()=>{
+    if (path.includes('places')) {
+      // 
+    } else if (path.includes('plans')) {
+      // 사용자 선택할 수 있게
+    }
+  },[path])
 
   useEffect(() => {
     console.log(state);
@@ -51,6 +60,7 @@ export default function ConnectPlace() {
           return place;
         });
         setPlanData({ ...planData, content: newArray });
+        console.log("잘 들어갔는가?", planData);
         fetchData(`/api/plans/${planInfor.planId}`, "PUT", planData);
 
         opener.location.reload();
@@ -91,10 +101,15 @@ export default function ConnectPlace() {
       return;
     }
 
-    const formattedDate = visitDate.toISOString().slice(0, 10);
+    const date = new Date(visitDate);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1; 
+    const day = date.getDate();
+
+    const formattedDate = `${year}-${month}-${day}`
 
     // 정보 보내기
-    setResultData({
+    const result = {
       reviewTitle: title,
       visitDate: formattedDate,
       place: place,
@@ -103,11 +118,13 @@ export default function ConnectPlace() {
       reviewSecret: false,
       thumbnail: representImage,
       planId: planInfor.planId,
-    })
+    }
+    setResultData(result)
 
     const response = window.confirm('리뷰 연동 게시글은 나만 보기 설정이 되지 않습니다. 연동하시겠습니까?');
     if (response) {
-      const json = JSON.stringify(resultData);
+      const json = JSON.stringify(result);
+      console.log(json);
       fetchData('/api/reviews', "POST", json);
     }
   }

--- a/trizzle-front/src/pages/AddPlace/ConnectPlace.tsx
+++ b/trizzle-front/src/pages/AddPlace/ConnectPlace.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import Page from "../Page";
 import * as S from "./AddPlace.styles";
 import TextInput from "../../components/TextInput";
@@ -6,32 +7,77 @@ import AddPlaceModal from "../../shared/SearchPlaceModal";
 import PostInput from "../../shared/PostEditor";
 import ScretDropdown from "../../shared/ScretDropdown";
 import DatePicker from "../../components/DatePicker";
-import { useNavigate, useParams } from "react-router-dom";
 import { useAsync } from "../../utils/API/useAsync";
 import { koreaRegions } from "../../utils/Data/mapData";
 
 export default function ConnectPlace() {
-  const navigate = useNavigate();
-  const planInfor = useParams<{ planId: string, placeName: string }>();
-  const [state, fetchData] = useAsync({ url: "", method: "" });
+  const planInfor = useParams<{ planDay: string, planId: string, placeId: string }>();
+  const [state, fetchData] = useAsync({ url: `/api/plans/${planInfor.planId}` });
+  const [planData, setPlanData] = useState<any>({});
+  const [planDataContent, setPlanDataContent] = useState<any>([]);
   const [title, setTitle] = useState<string>('');
-  const [secretValue, setSecretValue] = useState<boolean>(true);
+  const [secretValue, setSecretValue] = useState<boolean>(false);
   const [visitDate, setVisitDate] = useState<any>(new Date());
-  const [place, setPlace] = useState<any>({ placeName: planInfor.placeName });
+  const [place, setPlace] = useState<any>({ placeName: planInfor.placeId });
   const [contents, setContents] = useState<string>('');
   const [isPlusPlaceModal, setIsPlusPlaceModal] = useState<boolean>(false);
   const [contentsText, setContentsText] = useState<string>('');
   const region: any = koreaRegions[0];
   const [representImage, setRepresentImage] = useState<string>(''); // 대표이미지
+  const [resultData, setResultData] = useState<any>({});
 
   useEffect(() => {
     console.log(state);
     if (state.error) {
       console.error(state.error);
     } else if (state.data) {
-      if (state.data.message === "save success") navigate(`/post/places/${state.data.reviewId}`);
+      if (state.data.message === "save success") {
+        setResultData({ ...resultData, id: state.data.reviewId })
+        const dayValue = parseInt(planInfor.planDay ? planInfor.planDay : '1', 10);
+        const newArray = [...planDataContent];
+
+        if (!newArray[dayValue - 1]) {
+          newArray[dayValue - 1] = { placeList: [] };
+        }
+
+        // dayValue에 해당하는 placeList를 업데이트
+        newArray[dayValue - 1].placeList = (newArray[dayValue - 1].placeList || []).map((place: any) => {
+          // _id와 ConnectPlaceModalData.placeId를 비교하여 객체를 찾습니다.
+          if (place.id === planInfor.placeId) {
+            // 객체를 복사하여 reviewId를 추가한 후 반환합니다.
+            return { ...place, review: resultData };
+          }
+          // 찾지 못한 경우 해당 객체를 그대로 반환합니다.
+          return place;
+        });
+        setPlanData({ ...planData, content: newArray });
+        fetchData(`/api/plans/${planInfor.planId}`, "PUT", planData);
+
+        opener.location.reload();
+        window.close();
+      }
+      else if (planInfor) {
+        setPlanData(state.data);
+        setPlanDataContent(state.data.content);
+      }
     }
   }, [state]);
+
+  useEffect(() => {
+    if (planDataContent.length !== 0) {
+      const dayValue = parseInt(planInfor.planDay ? planInfor.planDay : '1', 10);
+      const placeInfor = planDataContent[(dayValue - 1)].placeList.filter((item: any) => item.id === planInfor.placeId) || [];
+      setPlace(placeInfor[0]);
+    }
+  }, [planDataContent, planInfor.planDay, planInfor.placeId]);
+
+  useEffect(() => {
+    if (planData.length !== 0 && planInfor.planDay !== '0') {
+      const dayValue = parseInt(planInfor.planDay ? planInfor.planDay : '1', 10);
+      const formatDate = new Date(planData.planStartDate);
+      setVisitDate( formatDate.setDate(formatDate.getDate() + (dayValue - 1)));
+    }
+  }, [planData, planInfor.planDay]);
 
   const onSave = () => {
     if (title === '') {
@@ -40,26 +86,28 @@ export default function ConnectPlace() {
     } else if (new Date() < visitDate) {
       alert("아직 지나지 않은 날짜입니다");
       return;
+    } else if (contents === '') {
+      alert("내용이 입력되지 않았습니다");
+      return;
     }
 
     const formattedDate = visitDate.toISOString().slice(0, 10);
 
     // 정보 보내기
-    const ResultData = {
+    setResultData({
       reviewTitle: title,
       visitDate: formattedDate,
       place: place,
       reviewContent: contents,
       reviewContentText: contentsText,
-      reviewSecret: secretValue,
+      reviewSecret: false,
       thumbnail: representImage,
       planId: planInfor.planId,
-    }
+    })
 
     const response = window.confirm('리뷰 연동 게시글은 나만 보기 설정이 되지 않습니다. 연동하시겠습니까?');
     if (response) {
-      const json = JSON.stringify(ResultData);
-      console.log(ResultData);
+      const json = JSON.stringify(resultData);
       fetchData('/api/reviews', "POST", json);
     }
   }
@@ -71,9 +119,9 @@ export default function ConnectPlace() {
       </S.PageTitleContainer>
       <form>
         <S.ButtonContainer>
-          <ScretDropdown titleValue={secretValue} onScret={(e) => setSecretValue(e)} />
+          <ScretDropdown titleValue={secretValue} onScret={(e) => setSecretValue(e)} disapled={true} />
           <div>
-            <S.Button type="button" onClick={onSave}>저장</S.Button>
+            <S.Button type="button" onClick={onSave} >저장</S.Button>
           </div>
         </S.ButtonContainer>
         <S.FormContainer>
@@ -81,14 +129,9 @@ export default function ConnectPlace() {
           <S.HorizontalSpaceBetweenContainer>
             <S.HorizontalFirstStartContainer>
               <S.SelectTitle>장소</S.SelectTitle>
-              {place && place.placeName !== '' ?
-                <S.HorizontalFirstStartContainer style={{ width: 'auto' }}>
-                  <div style={{ marginRight: '1.5rem', color: '#747474', fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif', fontSize: '1rem' }}>{place.placeName}</div>
-                  <S.SelectPlaceButton onClick={() => setIsPlusPlaceModal(!isPlusPlaceModal)} type="button">장소 변경</S.SelectPlaceButton>
-                </S.HorizontalFirstStartContainer>
-                :
-                <S.SelectPlaceButton onClick={() => setIsPlusPlaceModal(!isPlusPlaceModal)} type="button">장소 추가</S.SelectPlaceButton>
-              }
+              <S.HorizontalFirstStartContainer style={{ width: 'auto' }}>
+                <div style={{ marginRight: '1.5rem', color: '#747474', fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif', fontSize: '1rem' }}>{place.placeName}</div>
+              </S.HorizontalFirstStartContainer>
             </S.HorizontalFirstStartContainer>
             <S.HorizontalFirstStartContainer>
               <S.SelectTitle>방문날짜</S.SelectTitle>
@@ -96,7 +139,7 @@ export default function ConnectPlace() {
             </S.HorizontalFirstStartContainer>
           </S.HorizontalSpaceBetweenContainer>
           {/*게시글 에디터 자리*/}
-          <PostInput prevData={contents} onChangeContents={(con) => setContents(con)} onThumbnailImages={(img) => setRepresentImage(img)} onChangeContentsText={(con)=> setContentsText(con)}/>
+          <PostInput prevData={contents} onChangeContents={(con) => setContents(con)} onThumbnailImages={(img) => setRepresentImage(img)} onChangeContentsText={(con) => setContentsText(con)} />
 
         </S.FormContainer>
       </form>

--- a/trizzle-front/src/pages/AddPostPlan/AddPostPlan.tsx
+++ b/trizzle-front/src/pages/AddPostPlan/AddPostPlan.tsx
@@ -6,9 +6,8 @@ import DropdownMenu from "../../components/DropdownMenu";
 import Page from "../Page";
 import { koreaRegions } from "../../utils/Data/mapData";
 import { tripThema } from "../../utils/Data/tripThema";
-import UploadPlanModal from "../../shared/UploadPlanModal";
 import PlanMap from "../../shared/PlanMap";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useAsync } from "../../utils/API/useAsync";
 import DayPlanPost from "../../shared/DayPlanPost/DayPlanPost";
 import ConnectPlaceModal from "../../shared/ConnectPlaceModal";
@@ -25,13 +24,12 @@ const AddPostPlan: React.FC = () => {
   const [secret, setSecret] = useState<boolean>(true);
   const [selectedDayPlan, setSelectedDayPlan] = useState<any>(null);
   const [selectDay, setSelectDay] = useState<number>(0);
-  const [isUploadPlanModal, setIsUploadPlanModal] = useState<boolean>(false);
 
   const [isConnectPlaceModal, setIsConnectPlaceModal] = useState<boolean>(false);
   const [ConnectPlaceModalData, setConnectPlaceModalData] = useState<string>('');
   const [ConnectPlaceModalDay, setConnectPlaceModalDay] = useState<number>(0);
-  const [isHovered, setIsHovered] = useState<boolean>(false);
-  const [state, fetchData] = useAsync({ url: "", method: "" });
+  const planId = useParams<{ id: string }>();
+  const [state, fetchData] = useAsync({ url: `/api/plans/${planId.id}` });
 
   const navigate = useNavigate();
 
@@ -40,18 +38,19 @@ const AddPostPlan: React.FC = () => {
     if (state.error) {
       console.error(state.error);
     } else if (state.data) {
-      console.log(state.data);
+      console.log(state.data)
       if (state.data.message === "update success" && state.data.reviewId) {
         // setData({ ...state.data, reviewId: state.data.reviewId });
       }
-      // 저장 및 수정
       else if (!secret && state.data.message === "save success") navigate(`/post/plan/${state.data.postId}`);
       else if (secret && state.data.message === "save success") navigate(`/post/plan/secret/${state.data.postId}`);
+      else setData(state.data);
     }
   }, [state]);
 
   useEffect(() => {
     if (data.length !== 0) {
+      console.log("새로고참", data);
       setTitle(data.planName);
       setStartDate(data.planStartDate);
       setEndDate(data.planEndDate);
@@ -81,14 +80,15 @@ const AddPostPlan: React.FC = () => {
     const itemExists = thema.some((item: any) => item.id === select.id);
 
     if (itemExists) {
-      setThema((prev: any) => prev.filter((item:any) => item.id !== select.id));
+      setThema((prev: any) => prev.filter((item: any) => item.id !== select.id));
     } else {
       setThema((prev: any) => [...prev, select]);
     }
   };
 
-  const onPostPlace = (data: any) => {
-    window.open(`/post/places/add/${data._id}/${encodeURIComponent(data.placeName)}`, '_blank');
+  const onPostPlace = (day: number, placeData: any) => {
+    console.log("들어온 장소 데이터", placeData);
+    window.open(`/post/plans/add/${day}/${planId.id}/${placeData.id}`, '_blank');
   }
 
   const connectPlace = (day: number, data: any) => {
@@ -177,24 +177,17 @@ const AddPostPlan: React.FC = () => {
         <S.HorizontalLine />
       </S.FormContainer>
 
-      {data.length !== 0 ? (
         <S.MapAndDayPlanContainer>
           {data.content && <PlanMap selectDay={selectDay} setSelectDay={(day: number) => setSelectDay(day)} placeList={data.content} center={koreaRegions.filter((region) => { return region.name === regions })[0].center} page="detail" width="50%" />}
           <S.DayPlanPostContainer>
             <S.DayPlanPostInnerContainer>
-              <DayPlanPost planId={data.id} dayList={selectedDayPlan} selectDay={selectDay} onNewPostPlace={(data: any) => onPostPlace(data)} onConnetPostPlace={(day: number, data: any) => connectPlace(day, data)} />
+              <DayPlanPost planId={data.id} dayList={selectedDayPlan} selectDay={selectDay} onNewPostPlace={(day: number, data: any) => onPostPlace(day, data)} onConnetPostPlace={(day: number, data: any) => connectPlace(day, data)} />
             </S.DayPlanPostInnerContainer>
           </S.DayPlanPostContainer>
         </S.MapAndDayPlanContainer>
-      ) : (
-        <S.UploadContainer onClick={() => setIsUploadPlanModal(!isUploadPlanModal)} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
-          <S.UploadPlanButton onClick={() => setIsUploadPlanModal(!isUploadPlanModal)} isHovered={isHovered} >일정 불러오기</S.UploadPlanButton>
-        </S.UploadContainer>
-      )}
-      {/* </form> */}
-
+      
       <div style={{ height: "10rem" }} />
-      {isUploadPlanModal && <UploadPlanModal onclose={() => setIsUploadPlanModal(!isUploadPlanModal)} onClickedPlan={(plan: any) => setData(plan)} />}
+      
       {isConnectPlaceModal && <ConnectPlaceModal placeInfor={ConnectPlaceModalData} onclose={() => setIsConnectPlaceModal(!isConnectPlaceModal)} onClickedPlace={(place: any) => connectReview(place)} />}
     </Page >
   )

--- a/trizzle-front/src/pages/AddPostPlan/AddPostPlanOpen.tsx
+++ b/trizzle-front/src/pages/AddPostPlan/AddPostPlanOpen.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import * as S from './AddPostPlan.styles'
+import Page from "../Page";
+import TextInput from "../../components/TextInput";
+import DropdownMenu from "../../components/DropdownMenu";
+import UploadPlanModal from "../../shared/UploadPlanModal";
+import { tripThema } from "../../utils/Data/tripThema";
+
+const AddPostPlanOpen: React.FC = () => {
+  const [title, setTitle] = useState<string>('');
+  const [startDate, setStartDate] = useState<string>('');
+  const [endDate, setEndDate] = useState<string>('');
+  const [regions, setRegions] = useState<string>('서울특별시');
+  const [thema, setThema] = useState<any>([]);
+  const [isUploadPlanModal, setIsUploadPlanModal] = useState<boolean>(false);
+
+  const [isHovered, setIsHovered] = useState<boolean>(false);
+
+  const navigate = useNavigate();
+
+  const onSave = () => {
+    alert("불러온 일정이 없습니다.")
+  }
+
+  const uploadPlanData = (planData: any) => {
+    navigate(`/post/plans/add/${planData.id}`);
+  } 
+
+  return (
+    <Page headersProps={{ isHome: false }}>
+      <S.PageTitleContainer>
+        <S.PageTitle>일정 게시글 등록</S.PageTitle>
+      </S.PageTitleContainer>
+      {/* <form> */}
+      <S.ButtonContainer>
+        <S.Button onClick={onSave}>임시저장</S.Button>
+        <S.Button onClick={onSave}>게시</S.Button>
+      </S.ButtonContainer>
+      <S.FormContainer>
+        <TextInput name="title" title="제목" placeholder="일정 제목을 입력해주세요." styleProps={{ width: "100%" }} id="title" onChange={(event) => setTitle(event.target.value)} value={title} />
+        <S.HorizontalContainer>
+          <S.SelectTitle>지역</S.SelectTitle>
+          <div>{regions}</div>
+          <S.PlanDateContainer>
+            <S.SelectTitle >여행기간</S.SelectTitle>
+            <div>{startDate}</div>
+            <div style={{ color: "#7e7e7e", margin: "0 0.5rem 0 0.3rem", fontSize: "1.3rem" }}>~</div>
+            <div>{endDate}</div>
+          </S.PlanDateContainer>
+        </S.HorizontalContainer>
+        <S.HorizontalContainer>
+          <S.DropTitle>여행테마</S.DropTitle>
+          <DropdownMenu type="badge" name="여행테마를 선택해주세요" items={tripThema} selectedItem={thema} onClick={(thema) => onThemaBadgeClick(thema)} />
+        </S.HorizontalContainer>
+        <S.HorizontalLine />
+      </S.FormContainer>
+
+      <S.UploadContainer onClick={() => setIsUploadPlanModal(!isUploadPlanModal)} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+        <S.UploadPlanButton onClick={() => setIsUploadPlanModal(!isUploadPlanModal)} isHovered={isHovered} >일정 불러오기</S.UploadPlanButton>
+      </S.UploadContainer>
+
+      <div style={{ height: "10rem" }} />
+      {isUploadPlanModal && <UploadPlanModal onclose={() => setIsUploadPlanModal(!isUploadPlanModal)} onClickedPlan={(plan: any) => uploadPlanData(plan)} />}
+    </Page >
+  )
+}
+
+export default AddPostPlanOpen;

--- a/trizzle-front/src/pages/PlanDetail/index.tsx
+++ b/trizzle-front/src/pages/PlanDetail/index.tsx
@@ -66,7 +66,7 @@ const PlanDetail: React.FC = () => {
         <PlanMap selectDay={selectDay} setSelectDay={(day:number) => setSelectDay(day)} placeList={data.content} center={koreaRegions.filter((region) => {return region.name === data.planLocation})[0].center} page="detail"/>
         <HorizontalScrollContainer moveDistance={200}>
           {data.content.map((dayPlan:any, index:number) => (
-            <DetailDayPlan key={index} dayPlan={dayPlan} isPlan={false} onPostClick={() => {}}/>
+            <DetailDayPlan key={index} dayPlan={dayPlan} isPlan={false} onPostClick={() => {}} id={data.id}/>
           ))}
         </HorizontalScrollContainer>
       </S.Container>

--- a/trizzle-front/src/pages/PostPlan/PostPlan.styles.tsx
+++ b/trizzle-front/src/pages/PostPlan/PostPlan.styles.tsx
@@ -39,7 +39,7 @@ export const InforFirstContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 2rem;
+  margin-top: 7rem;
   margin-bottom: 1.5rem;
 
   font-size: 2rem;
@@ -50,7 +50,7 @@ export const InforContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin-bottom: 1.5rem;
-  width: 5rem;
+  width: auto;
   font-weight: bold;
   font-size: 1.1rem;
 `
@@ -61,7 +61,6 @@ export const InforInputContainer = styled.div`
   font-size: 1rem;
 `
 
-
 export const Content = styled.div`
   width: auto;
   height: auto;
@@ -70,7 +69,7 @@ export const Content = styled.div`
   color: #747474;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.7rem;
 `
 
 export const ThemaBadge = styled.div`

--- a/trizzle-front/src/pages/PostPlan/PostPlan.tsx
+++ b/trizzle-front/src/pages/PostPlan/PostPlan.tsx
@@ -11,6 +11,7 @@ import { useAsync } from "../../utils/API/useAsync";
 import { useParams } from "react-router-dom";
 import { tripThema } from "../../utils/Data/tripThema";
 import CommentSection from "../../shared/CommentSection";
+import SearchBar from "../../components/SearchBar";
 
 const PostPlan: React.FC = () => {
   const [data, setData] = useState<any>([]);
@@ -37,6 +38,7 @@ const PostPlan: React.FC = () => {
       alert("데이터를 불러오는 데 실패했습니다");
     } else if (state.data) {
       setData(state.data);
+      console.log(state.data);
     }
   }, [state]);
 
@@ -63,6 +65,8 @@ const PostPlan: React.FC = () => {
 
   return (
     <Page headersProps={{ isHome: false }}>
+      <SearchBar type="normal"/>
+
       <S.InforFirstContainer>
         <div>제목 {title}</div>
       </S.InforFirstContainer>
@@ -113,7 +117,7 @@ const PostPlan: React.FC = () => {
             추천수
           </S.InforContainer>
           <S.InforInputContainer>
-            {data.bookmarks}
+            {data.likeCount}
           </S.InforInputContainer>
         </S.HorizontalFirstStartContainer>
         <S.HorizontalFirstStartContainer>
@@ -121,7 +125,7 @@ const PostPlan: React.FC = () => {
             북마크수
           </S.InforContainer>
           <S.InforInputContainer>
-            {data.comments}
+            {data.bookmarkCount}
           </S.InforInputContainer>
         </S.HorizontalFirstStartContainer>
       </S.HorizontalContainer>
@@ -135,7 +139,7 @@ const PostPlan: React.FC = () => {
         </S.DayPlanPostContainer>
       </S.MapAndDayPlanContainer>
 
-      <UserPreview nickName="날탱이탱날" keyword={["배낭", "자전거"]} />
+      <UserPreview nickName={data.accountId} keyword={["배낭", "자전거"]} />
 
       <S.CommentContainer>
         <S.HorizontalFirstStartContainer>

--- a/trizzle-front/src/route/index.tsx
+++ b/trizzle-front/src/route/index.tsx
@@ -33,6 +33,7 @@ const Router = () => {
 
         <Route path='/post/plans/add' element={<AddPostPlanOpen />} />
         <Route path='/post/plans/add/:id' element={<AddPostPlan />} />
+        <Route path="/post/places/add/:planDay/:planId/:placeId" element={<ConnectPlace />} />
         <Route path="/post/plans/add/:planDay/:planId/:placeId" element={<ConnectPlace />} />
         <Route path='/post/plan/:id' element={<PostPlan />} />
 

--- a/trizzle-front/src/route/index.tsx
+++ b/trizzle-front/src/route/index.tsx
@@ -15,6 +15,7 @@ import AddPostPlan from '../pages/AddPostPlan/AddPostPlan';
 import PostPlan from '../pages/PostPlan/PostPlan';
 import GoogleRedirectPage from '../pages/GoogleRedirectPage/GoogleRedirectPage';
 import ConnectPlace from '../pages/AddPlace/ConnectPlace';
+import AddPostPlanOpen from '../pages/AddPostPlan/AddPostPlanOpen';
 
 const Router = () => {
   return (
@@ -30,8 +31,9 @@ const Router = () => {
         <Route path='/search/:region/places' element={<SearchPlace />} />
         <Route path='/search/:region/plans' element={<SearchPlan />} />
 
-        <Route path='/post/plans/add' element={<AddPostPlan />} />
-        <Route path="/post/plans/add/:planId/:placeName" element={<ConnectPlace />} />
+        <Route path='/post/plans/add' element={<AddPostPlanOpen />} />
+        <Route path='/post/plans/add/:id' element={<AddPostPlan />} />
+        <Route path="/post/plans/add/:planDay/:planId/:placeId" element={<ConnectPlace />} />
         <Route path='/post/plan/:id' element={<PostPlan />} />
 
         <Route path="/post/places/:id" element={<PostPlace />} />

--- a/trizzle-front/src/shared/DayPlan/DayPlace.tsx
+++ b/trizzle-front/src/shared/DayPlan/DayPlace.tsx
@@ -22,10 +22,10 @@ type DayPlaceProps = {
 }
 
 const KeywordList: { keyword: string; src: string; }[] = [
-  {keyword:"식사", src: res},
-  {keyword:"이동", src: trans},
-  {keyword:"휴식", src: rest},
-  {keyword:"쇼핑", src: shopping},
+  { keyword: "식사", src: res },
+  { keyword: "이동", src: trans },
+  { keyword: "휴식", src: rest },
+  { keyword: "쇼핑", src: shopping },
 ];
 
 const DayPlace: React.FC<DayPlaceProps> = (props: DayPlaceProps) => {
@@ -35,18 +35,11 @@ const DayPlace: React.FC<DayPlaceProps> = (props: DayPlaceProps) => {
   const [menuItem, setMenuItem] = useState<any[]>([]);
 
   const handleNavigation = () => {
-
-    const data = {
-      placeId: props.place.id,
-      placeName: props.place.placeName,
-    };
-
-    const queryString = new URLSearchParams(data).toString();
-    navigate(`/post/places/add/?${queryString}`);
+    navigate(`/post/places/add/${props.day}/${props.id ? props.id : '' }/${props.place.id}`);
   };
 
-  const onPostClick =() => {
-    if(props.secret && props.secret === true) navigate(`/post/places/secret/${props.id}`)
+  const onPostClick = () => {
+    if (props.secret && props.secret === true) navigate(`/post/places/secret/${props.id}`)
     navigate(`/post/places/secret/${props.id}`)
   }
 
@@ -55,7 +48,7 @@ const DayPlace: React.FC<DayPlaceProps> = (props: DayPlaceProps) => {
       const keywordSrc = KeywordList.filter((key) => props.place.keyword === key.keyword);
       setKeyword(keywordSrc);
       if (props.onDeleteClick) {
-        setMenuItem([{ content: "삭제", onClick: () => {props.onDeleteClick && props.onDeleteClick(props.place, props.day, props.index) }}]);
+        setMenuItem([{ content: "삭제", onClick: () => { props.onDeleteClick && props.onDeleteClick(props.place, props.day, props.index) } }]);
       }
     } else {
       if (props.isPlan && props.onDeleteClick) {
@@ -67,7 +60,7 @@ const DayPlace: React.FC<DayPlaceProps> = (props: DayPlaceProps) => {
       }
     }
   }, [props.place, props.day, props.index, props.onDeleteClick, props.isPlan, props.isPost, props.id]);
-  
+
 
   if (keyword === null) {
     return (
@@ -85,16 +78,17 @@ const DayPlace: React.FC<DayPlaceProps> = (props: DayPlaceProps) => {
       </S.PlaceContainer>
     )
   } else {
-    if(keyword !== null){
-    return (
-      <S.PlaceContainer>
-        {menuItem.length !== 0 &&
-          <Menu item={menuItem} />
-        }
-        <img src={keyword[0].src} alt="keywordImg" style={{ width: "3.2rem", height: "auto" }} />
-        <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{keyword[0].keyword}</S.PlaceAddress>
-      </S.PlaceContainer>
-    )} else {
+    if (keyword !== null) {
+      return (
+        <S.PlaceContainer>
+          {menuItem.length !== 0 &&
+            <Menu item={menuItem} />
+          }
+          <img src={keyword[0].src} alt="keywordImg" style={{ width: "3.2rem", height: "auto" }} />
+          <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{keyword[0].keyword}</S.PlaceAddress>
+        </S.PlaceContainer>
+      )
+    } else {
       <></>
     }
   }

--- a/trizzle-front/src/shared/DayPlan/DetailDayPlan.tsx
+++ b/trizzle-front/src/shared/DayPlan/DetailDayPlan.tsx
@@ -6,6 +6,7 @@ import DayPlace from "./DayPlace";
 
 type DayPlanProps = {
   dayPlan: dayPlan;
+  id: string;
   isPlan: boolean;
   isPost?: boolean;
   onPostClick?: () => void;
@@ -25,7 +26,7 @@ const DetailDayPlan: React.FC<DayPlanProps> = (props: DayPlanProps) => {
     <S.DayPlanContainer>
         <S.DayPlanTitle>{props.dayPlan.day}일차</S.DayPlanTitle>
         {props.dayPlan.placeList.length > 0 && props.dayPlan.placeList.map((place, index) => (
-          <DayPlace key={index} place={place} day={props.dayPlan.day} isPlan={props.isPlan} isPost={props.isPost} onPostClick={props.onPostClick} index={index} />
+          <DayPlace key={index} place={place} day={props.dayPlan.day} isPlan={props.isPlan} isPost={props.isPost} onPostClick={props.onPostClick} index={index} id={props.id} />
         ))
         }
     </S.DayPlanContainer>

--- a/trizzle-front/src/shared/DayPlanPost/DayPlanPost.styles.tsx
+++ b/trizzle-front/src/shared/DayPlanPost/DayPlanPost.styles.tsx
@@ -39,9 +39,8 @@ export const PalceText = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 1rem 0 2rem 0;
+  margin: 1.15rem;
   width: auto;
-  height: 3.2rem;
 
   font-size: 1.5rem;
   font-weight: 700;
@@ -49,18 +48,44 @@ export const PalceText = styled.div`
 
 export const ThreeDotsButton = styled.button`
   position: relative;
-  margin: 0.2rem 0 0 0;
-  top: 0.25rem;
+  top: 0;
   left: 25.5rem;
+  margin: 0.2rem 0 0 0;
   width: auto;
-  color: #BEBEBE;
+  color: #000000;
+  z-index: 100;
+  &:hover {
+    font-weight: 600;
+  }
+`
+
+export const ModifyButton = styled.button`
+  margin: 0.5rem 0.5rem 0 0;
+  width: 2rem;
+  font-size: 1rem;
+  color: #000000;
+  z-index: 100;
   &:hover {
     font-weight: 600;
   }
 `
 
 export const PlacePostContainer = styled.div`
-  display: block;
+  display: flex;
+  align-items: center;
+  margin: 1rem;
+  width: 28rem;
+  height: 8rem;
+  border: 1.5px solid #FFDC61;
+  border-radius: 1rem;
+  &:hover{
+    background-color: rgba(255, 220, 97, 0.2);
+  }
+`
+
+export const PlacePostNoneContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
   margin: 1rem;
   width: 28rem;
   height: 8rem;
@@ -75,9 +100,8 @@ export const PlaceLogo = styled.div`
   width: 30%;
   height: 100%;
   background-color: #FFECAA;
-  border-top-left-radius: 0.75rem;
-  border-bottom-left-radius: 0.75rem;
-  position: relative;
+  border-top-left-radius: 0.9rem;
+  border-bottom-left-radius: 0.9rem;
   top: -1.2rem;
 `
 
@@ -95,13 +119,12 @@ export const PlaceImage = styled.img`
 `
 
 export const PlaceInfo = styled.div`
-  width: 60%;
-  height: 100%;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   justify-content: center;
-  padding: 0 0.5rem;
+  margin: 1.1rem 0 0 0.5rem;
+  width: 60%;
+  height: 100%;
 `
 
 export const PlaceName = styled.div`
@@ -126,6 +149,7 @@ export const ToggleButtonContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin: 0.5rem;
   background-color: #FFFFFF;
   border-radius: 0.5rem;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
@@ -136,7 +160,7 @@ export const ToggleButtonContainer = styled.div`
 
   position: absolute;
   top: 1rem;
-  left: -4rem;
+  left: -5rem;
 `
 
 export const ToggleButtonOption = styled.button`
@@ -153,5 +177,7 @@ export const ToggleButtonOption = styled.button`
   cursor: pointer;
   &:hover{
     background-color: #E9E9E9;
+    font-weight: 500;
+    color: #000000;
   }
 `

--- a/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
+++ b/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
@@ -63,7 +63,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                 {plans.placeList.map((place: any, innerIndex: number) => (
                   <div>
                     {place.review && place.review !== null ? (
-                      <Link to={`${import.meta.env.VITE_PUBLIC_URL}post/places/${place.review.id}`} target="_blank"> {/**잠시 고민 좀 해봐야겠어 */}
+                      <Link to={`/post/places/${place.review.id}`} target="_blank"> {/**잠시 고민 좀 해봐야겠어 */}
                         <S.PlacePostContainer>
                           <div style={{ width: '100%', height: '100%' }}>
                             {

--- a/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
+++ b/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
@@ -65,31 +65,37 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                     {place.review && place.review !== null ? (
                       <Link to={`${import.meta.env.VITE_PUBLIC_URL}post/places/${place.review.id}`} target="_blank"> {/**잠시 고민 좀 해봐야겠어 */}
                         <S.PlacePostContainer>
-                          {
-                            place.review.thumbnail === '' ?
-                              <S.PlaceLogo>
-                                <img src={logo} alt="logo" style={{ width: "2.2rem", height: "auto" }} />
-                              </S.PlaceLogo>
-                              :
-                              <S.PlaceImage src={place.review.thumbnail} alt="image" />
-                          }
-                          <S.PlaceInfo>
-                            <S.PlaceName>{place.review.reviewTitle}</S.PlaceName>
-                            <S.PlacePostName>{place.review.place.placeName}</S.PlacePostName>
-                          </S.PlaceInfo>
+                          <div style={{ width: '100%', height: '100%' }}>
+                            {
+                              place.review.thumbnail === '' ?
+                                <S.PlaceLogo>
+                                  <img src={logo} alt="logo" style={{ width: "2.2rem", height: "auto" }} />
+                                </S.PlaceLogo>
+                                :
+                                <S.PlaceImage src={place.review.thumbnail} alt="image" />
+                            }
+                            <S.PlaceInfo>
+                              <S.PlaceName>{place.review.reviewTitle}</S.PlaceName>
+                              <S.PlacePostName>{place.review.place.placeName}</S.PlacePostName>
+                            </S.PlaceInfo>
+                          </div>
                         </S.PlacePostContainer>
                       </Link>
                     ) : (
                       place.keyword !== null ? (
                         <S.PlaceContainer key={innerIndex} type={true}>
-                          <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
-                          <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.PlaceAddress>
+                          <div style={{ width: '100%', height: '100%' }}>
+                            <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
+                            <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.PlaceAddress>
+                          </div>
                         </S.PlaceContainer>
                       ) : (
                         <S.PlaceContainer key={innerIndex} >
-                          <S.PalceText>
-                            {place.placeName}
-                          </S.PalceText>
+                          <div style={{ width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                            <S.PalceText>
+                              {place.placeName}
+                            </S.PalceText>
+                          </div>
                         </S.PlaceContainer>
                       )
                     )}
@@ -117,8 +123,22 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                 {plans.placeList.map((place: any, innerIndex: number) =>
                   <div>
                     {place.review && place.review !== null ? (
-                      <S.PlacePostContainer>
-                        <S.ThreeDotsButton onClick={() => openAndCloseDetail(index, innerIndex)}>
+                      <S.PlacePostNoneContainer>
+                        <div style={{ width: '100%', height: '100%' }}>
+                          {
+                            place.review.thumbnail === '' ?
+                              <S.PlaceLogo>
+                                <img src={logo} alt="logo" style={{ width: "2.2rem", height: "auto" }} />
+                              </S.PlaceLogo>
+                              :
+                              <S.PlaceImage src={place.review.thumbnail} alt="image" />
+                          }
+                          <S.PlaceInfo>
+                            <S.PlaceName>{place.review.reviewTitle}</S.PlaceName>
+                            <S.PlacePostName>{place.review.place.placeName}</S.PlacePostName>
+                          </S.PlaceInfo>
+                        </div>
+                        <S.ModifyButton onClick={() => openAndCloseDetail(index, innerIndex)}>
                           수정
                           {isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
                             <S.ToggleButtonContainer>
@@ -128,42 +148,32 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                                   openAndCloseDetail(index, innerIndex);
                                 }
                               }}>
-                                새 게시글 작성
-                                </S.ToggleButtonOption>
+                                새 리뷰 작성
+                              </S.ToggleButtonOption>
                               <S.ToggleButtonOption onClick={() => {
                                 if (props.onConnetPostPlace) {
                                   props.onConnetPostPlace(plans.day, data[index].placeList[innerIndex]);
                                   openAndCloseDetail(index, innerIndex);
                                 }
                               }}>
-                                게시글 불러오기
+                                리뷰 불러오기
                               </S.ToggleButtonOption>
                             </S.ToggleButtonContainer>
                           }
-                        </S.ThreeDotsButton>
-                        {
-                          place.review.thumbnail === '' ?
-                            <S.PlaceLogo>
-                              <img src={logo} alt="logo" style={{ width: "2.2rem", height: "auto" }} />
-                            </S.PlaceLogo>
-                            :
-                            <S.PlaceImage src={place.review.thumbnail} alt="image" />
-                        }
-                        <S.PlaceInfo>
-                          <S.PlaceName>{place.review.reviewTitle}</S.PlaceName>
-                          <S.PlacePostName>{place.review.place.placeName}</S.PlacePostName>
-                        </S.PlaceInfo>
-                      </S.PlacePostContainer>
+                        </S.ModifyButton>
+                      </S.PlacePostNoneContainer>
                     ) : (
                       place.keyword !== null ? (
                         <S.PlaceContainer key={innerIndex} type={true}>
-                          <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
-                          <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.PlaceAddress>
+                          <div>
+                            <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
+                            <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.PlaceAddress>
+                          </div>
                         </S.PlaceContainer>
                       ) : (
                         <S.PlaceContainer key={innerIndex} >
                           <S.ThreeDotsButton onClick={() => openAndCloseDetail(index, innerIndex)}>
-                            <PiDotsThree size={20} />
+                            <PiDotsThree size={25} />
                             {isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
                               <S.ToggleButtonContainer>
                                 <S.ToggleButtonOption onClick={() => {
@@ -172,7 +182,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                                     openAndCloseDetail(index, innerIndex);
                                   }
                                 }}>
-                                  새 게시글 작성
+                                  새 리뷰 작성
                                 </S.ToggleButtonOption>
                                 <S.ToggleButtonOption onClick={() => {
                                   if (props.onConnetPostPlace) {
@@ -180,14 +190,16 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                                     openAndCloseDetail(index, innerIndex);
                                   }
                                 }}>
-                                  게시글 불러오기
+                                  리뷰 불러오기
                                 </S.ToggleButtonOption>
                               </S.ToggleButtonContainer>
                             }
                           </S.ThreeDotsButton>
-                          <S.PalceText>
-                            {place.placeName}
-                          </S.PalceText>
+                          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                            <S.PalceText>
+                              {place.placeName}
+                            </S.PalceText>
+                          </div>
                         </S.PlaceContainer>
                       )
                     )}

--- a/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
+++ b/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
@@ -14,7 +14,7 @@ type DayPlanPostProps = {
   planId?: string;
   dayList: any;
   selectDay: number;
-  onNewPostPlace?: (value: any) => void;
+  onNewPostPlace?: (day: number, value: any) => void;
   onConnetPostPlace?: (day: number, value: any) => void;
 }
 
@@ -29,7 +29,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
   const [data, setData] = useState<any>([]);
   const [isDdetailOpen, setIsDdetailOpen] = useState<any>([])
 
-  const openDetail = (idx: number, innerIdx: number) => {
+  const openAndCloseDetail = (idx: number, innerIdx: number) => {
     const newArray = [...isDdetailOpen];
     newArray[idx][innerIdx] = !newArray[idx][innerIdx];
     setIsDdetailOpen(newArray);
@@ -37,7 +37,6 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
 
   useEffect(() => {
     setData(props.dayList);
-    console.log("epdlxj", props.dayList);
   }, [props.dayList]);
 
   useEffect(() => {
@@ -115,17 +114,30 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                 <S.DayContainer key={index}>
                   {plans.day}일차
                 </S.DayContainer>
-                {plans.placeList.map((place: any, innerIndex: number) => (
+                {plans.placeList.map((place: any, innerIndex: number) =>
                   <div>
-                    {place.review && place.review !== null  ? (
+                    {place.review && place.review !== null ? (
                       <S.PlacePostContainer>
-                        <S.ThreeDotsButton >
+                        <S.ThreeDotsButton onClick={() => openAndCloseDetail(index, innerIndex)}>
                           수정
-                          {
-                            isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
+                          {isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
                             <S.ToggleButtonContainer>
-                              <S.ToggleButtonOption onClick={() => props.onNewPostPlace(data[index].placeList[innerIndex])}>새 게시글 작성</S.ToggleButtonOption>
-                              <S.ToggleButtonOption onClick={() => props.onConnetPostPlace(plans.day, data[index].placeList[innerIndex])}>게시글 불러오기</S.ToggleButtonOption>
+                              <S.ToggleButtonOption onClick={() => {
+                                if (props.onNewPostPlace) {
+                                  props.onNewPostPlace(plans.day, data[index].placeList[innerIndex]);
+                                  openAndCloseDetail(index, innerIndex);
+                                }
+                              }}>
+                                새 게시글 작성
+                                </S.ToggleButtonOption>
+                              <S.ToggleButtonOption onClick={() => {
+                                if (props.onConnetPostPlace) {
+                                  props.onConnetPostPlace(plans.day, data[index].placeList[innerIndex]);
+                                  openAndCloseDetail(index, innerIndex);
+                                }
+                              }}>
+                                게시글 불러오기
+                              </S.ToggleButtonOption>
                             </S.ToggleButtonContainer>
                           }
                         </S.ThreeDotsButton>
@@ -150,13 +162,27 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                         </S.PlaceContainer>
                       ) : (
                         <S.PlaceContainer key={innerIndex} >
-                          <S.ThreeDotsButton onClick={() => openDetail(index, innerIndex)}>
+                          <S.ThreeDotsButton onClick={() => openAndCloseDetail(index, innerIndex)}>
                             <PiDotsThree size={20} />
-                            {
-                              isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
+                            {isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
                               <S.ToggleButtonContainer>
-                                {/* <S.ToggleButtonOption onClick={() => props.onNewPostPlace(data[index].placeList[innerIndex])}>새 게시글 작성</S.ToggleButtonOption> */}
-                                <S.ToggleButtonOption onClick={() => props.onConnetPostPlace? props.onConnetPostPlace(plans.day, data[index].placeList[innerIndex]):null}>게시글 불러오기</S.ToggleButtonOption>
+                                <S.ToggleButtonOption onClick={() => {
+                                  if (props.onNewPostPlace) {
+                                    props.onNewPostPlace(plans.day, data[index].placeList[innerIndex]);
+                                    openAndCloseDetail(index, innerIndex);
+                                  }
+                                }}>
+                                  새 게시글 작성
+                                </S.ToggleButtonOption>
+                                <S.ToggleButtonOption onClick={() => {
+                                  if (props.onConnetPostPlace) {
+                                    props.onConnetPostPlace(plans.day, data[index].placeList[innerIndex]);
+                                    openAndCloseDetail(index, innerIndex);
+                                  }
+                                }}>
+                                  게시글 불러오기
+                                </S.ToggleButtonOption>
+                              </S.ToggleButtonContainer>
                             }
                           </S.ThreeDotsButton>
                           <S.PalceText>
@@ -166,7 +192,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                       )
                     )}
                   </div >
-                ))}
+                )}
               </>
             ))
             }

--- a/trizzle-front/src/shared/PostEditor/index.tsx
+++ b/trizzle-front/src/shared/PostEditor/index.tsx
@@ -31,8 +31,7 @@ export const PostInput: React.FC<PostInputProps> = (props: PostInputProps) => {
   }, []);
 
   useEffect(() => {
-    console.log("에디터에 들어온 데이터", props.prevData);
-    setData('<p><img src="https://trizzle-review.s3.ap-northeast-2.amazonaws.com/image/24ba9a7f-a017-4cc9-9d67-cd794a51f00b_%EC%9B%B9%20%EC%BA%A1%EC%B2%98_12-11-2023_21556_localhost.jpeg" alt="웹 캡처_12-11-2023_21556_localhost.jpeg"><img src="https://trizzle-review.s3.ap-northeast-2.amazonaws.com/image/24ba9a7f-a017-4cc9-9d67-cd794a51f00b_%EC%9B%B9%20%EC%BA%A1%EC%B2%98_12-11-2023_21556_localhost.jpeg" alt="웹 캡처_12-11-2023_21556_localhost.jpeg"></p>');
+    setData(props.prevData);
   }, [props.prevData]);
 
   const imageHandler = async () => {

--- a/trizzle-front/src/shared/ScretDropdown/index.tsx
+++ b/trizzle-front/src/shared/ScretDropdown/index.tsx
@@ -5,6 +5,7 @@ import { AiOutlineDown } from "react-icons/ai";
 type ScretDropdownPorps = {
   titleValue: boolean;
   onScret: (value: boolean) => void;
+  disapled?: boolean;
 }
 
 const ScretDropdown: React.FC<ScretDropdownPorps> = (props: ScretDropdownPorps) => {
@@ -24,8 +25,8 @@ const ScretDropdown: React.FC<ScretDropdownPorps> = (props: ScretDropdownPorps) 
 
   return (
     <>
-      <S.DropdownContainer>
-        <S.DropdownButton type="button" onClick={() => setIsOpen(!isOpen)}>
+      <S.DropdownContainer >
+        <S.DropdownButton type="button" onClick={() => setIsOpen(!isOpen)} disabled={props.disapled ? props.disapled : false}>
           {title}
           <AiOutlineDown size="1.1rem" />
         </S.DropdownButton>


### PR DESCRIPTION
## 관련 이슈
- #42

## 구현 기능
- 일정 게시글 작성 시 내 일정 불러오기 전, 후 페이지 분할
- 장소-리뷰 연동 과정 중 새 게시글 작성 기능 추가
- 이때 작성할 장소 및 시간 미리 화면에 표시
- 내 일정에서 리뷰 등록