### PR TITLE
[ADD]dto에 유저 정보 추가 및 홈 엔드포인트 생성

### DIFF
--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/configuration/AuthenticationConfig.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/configuration/AuthenticationConfig.java
@@ -38,8 +38,12 @@ public class AuthenticationConfig {
                                 new AntPathRequestMatcher("/api/upload/complete"),
                                 new AntPathRequestMatcher("/api/comments", "GET"),
                                 new AntPathRequestMatcher("/api/user/header", "GET"),
+                                new AntPathRequestMatcher("/api/user/feed/{accountId}", "GET"),
                                 new AntPathRequestMatcher("/api/posts/search", "GET"),
+                                new AntPathRequestMatcher("/api/posts/home", "GET"),
+                                new AntPathRequestMatcher("/api/posts/otherposts/{accountId}", "GET"),
                                 new AntPathRequestMatcher("/api/reviews/search", "GET"),
+                                new AntPathRequestMatcher("/api/reviews/otherreviews/{accountId}", "GET"),
                                 new AntPathRequestMatcher(("/api/inquiries/"), "GET")
                         ).permitAll()
                         .anyRequest().authenticated())

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/PostController.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/PostController.java
@@ -96,6 +96,13 @@ public class PostController {
                 .body(myPosts);
     }
 
+    @GetMapping("/otherposts/{accountId}")
+    public ResponseEntity getOtherPosts(@PathVariable("accountId") String accountId) {
+        List<Post> posts = postService.findMyPosts(accountId);
+        return ResponseEntity.ok()
+                .body(posts);
+    }
+
     @DeleteMapping("/myposts/{postId}")
     public ResponseEntity deleteMyPost(@PathVariable("postId") String postId, HttpServletRequest request) {
         String token = JwtUtil.getAccessTokenFromCookie(request);
@@ -132,6 +139,11 @@ public class PostController {
     @GetMapping("/home")
     public ResponseEntity getTop4Posts() {
         List<Post> posts = postService.findTop4Posts();
-        return ResponseEntity.ok(posts);
+        Page<ElasticPost> leasts = postService.findRandomPosts();
+        Map<String, Object> response = new HashMap<>();
+        response.put("top4", posts);
+        response.put("least", leasts);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
@@ -72,6 +72,13 @@ public class ReviewController {
                 .body(myReviews);
     }
 
+    @GetMapping("/otherreviews/{accountId}")
+    public ResponseEntity getOtherReviews(@PathVariable("accountId") String accountId) {
+        List<Review> reviews = reviewService.findMyReviews(accountId);
+        return ResponseEntity.ok()
+                .body(reviews);
+    }
+
     @GetMapping("/search")
     public ResponseEntity getSearchPost(@RequestParam(value = "region", required = false) String region,
                                         @RequestParam(value = "keyword", required = false) String keyword,

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/domain/ElasticReview.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/domain/ElasticReview.java
@@ -25,6 +25,7 @@ public class ElasticReview {
     private Place place;
     private String reviewContent;
     private boolean reviewSecret;
+    private String reviewContentText;
     private String planId;
     private String postId;
     private String postName;
@@ -48,7 +49,7 @@ public class ElasticReview {
 
     public void setData(String id, String accountId, String reviewTitle, LocalDateTime reviewRegistrationDate,
                    LocalDate visitDate, Place place, String reviewContent, String planId, String postId,
-                   String postName, String thumbnail, boolean reviewSecret, Integer likeCount, Integer bookmarkCount){
+                   String postName, String thumbnail, boolean reviewSecret, Integer likeCount, Integer bookmarkCount, String reviewContentText){
         this.id = id;
         this.accountId = accountId;
         this.reviewTitle = reviewTitle;
@@ -62,6 +63,7 @@ public class ElasticReview {
         this.thumbnail = thumbnail;
         this.reviewSecret = reviewSecret;
         this.likeCount = likeCount;
-        this.bookmarkCount = likeCount;
+        this.bookmarkCount = bookmarkCount;
+        this.reviewContentText = reviewContentText;
     }
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/dto/response/PostDto.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/dto/response/PostDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import trizzle.trizzlebackend.domain.Post;
+import trizzle.trizzlebackend.domain.User;
 
 @Getter
 @Setter
@@ -13,4 +14,5 @@ public class PostDto {
     private boolean isLike;
     @JsonProperty("isBookmark")
     private boolean isBookmark;
+    private User postUser;
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/dto/response/ReviewDto.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/dto/response/ReviewDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import trizzle.trizzlebackend.domain.Review;
+import trizzle.trizzlebackend.domain.User;
 
 @Getter
 @Setter
@@ -13,4 +14,5 @@ public class ReviewDto {
     private boolean isLike;
     @JsonProperty("isBookmark")
     private boolean isBookmark;
+    private User reviewUser;
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/ReviewService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/ReviewService.java
@@ -31,6 +31,7 @@ public class ReviewService {
     private final PlaceService placeService;
     private final BookmarkRepository bookmarkRepository;
     private final LikeRepository likeRepository;
+    private final UserService userService;
     @Value("${jwt.secret}")
     private String secretKey;
 
@@ -48,7 +49,7 @@ public class ReviewService {
         ElasticReview elasticReview = new ElasticReview();
         elasticReview.setData(insert.getId(), insert.getAccountId(), insert.getReviewTitle(), insert.getReviewRegistrationDate(),
                 insert.getVisitDate(), insert.getPlace(), insert.getReviewContent(), insert.getPlanId(), insert.getPostId(),
-                insert.getPostName(), insert.getThumbnail(), insert.isReviewSecret(), insert.getLikeCount(), insert.getBookmarkCount());
+                insert.getPostName(), insert.getThumbnail(), insert.isReviewSecret(), insert.getLikeCount(), insert.getBookmarkCount(), insert.getReviewContentText());
         elasticReviewRepository.save(elasticReview);
 
         return insert;
@@ -58,8 +59,10 @@ public class ReviewService {
         Optional<Review> reviewOptional = reviewRepository.findById((reviewId));
         if (reviewOptional.isPresent()) {   // reviewId에 해당하는 review가 있을 경우
             Review review = reviewOptional.get();
+            User reviewUser = userService.searchUser(review.getAccountId());
             ReviewDto reviewDto = new ReviewDto();
             reviewDto.setReview(review);
+            reviewDto.setReviewUser(reviewUser);
 
             if (review.isReviewSecret()) {  // 비공개일 경우 cookie의 accountId와 review의 accountId 비교
                 String token = JwtUtil.getAccessTokenFromCookie(request);


### PR DESCRIPTION
- 홈 엔드포인트 생성
- 각 dto에 유저정보 추가
   - 이유 : 게시글에는 작성자의 유저 정보를 보여주는 컴포넌트 존재. 해당 컴포넌트에 nickname / thema를 표시해야 함