### PR TITLE
[FEAT] 기타 수정 

### DIFF
--- a/trizzle-front/src/components/Footers/Footer.style.tsx
+++ b/trizzle-front/src/components/Footers/Footer.style.tsx
@@ -10,7 +10,7 @@ export const Container = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin: 1rem 5rem;
+  margin: 1rem 10rem;
   width: 100%;
 `
 export const HorizontalContainer = styled.div`

--- a/trizzle-front/src/components/Footers/index.tsx
+++ b/trizzle-front/src/components/Footers/index.tsx
@@ -26,25 +26,6 @@ const Footer: React.FC = () => {
             </div>
           </S.VerticalContainer>
 
-          {/**추후 설명 페이지 추가 */}
-          <S.VerticalContainer>
-            <S.LargeText>제공 서비스</S.LargeText>
-            <S.HorizontalContainer style={{ margin: '0.2rem 0 0 0.5rem' }}>
-              <S.MIddleText>리뷰 등록</S.MIddleText>
-              <S.Sortation>|</S.Sortation>
-              <S.MIddleText>내 일정 등록</S.MIddleText>
-              <S.Sortation>|</S.Sortation>
-              <S.MIddleText>일정 리뷰 연동</S.MIddleText>
-              <S.Sortation>|</S.Sortation>
-              <S.MIddleText>일정 복사</S.MIddleText>
-              <S.Sortation>|</S.Sortation>
-              <S.MIddleText>일정 / 장소 검색</S.MIddleText>
-              <S.Sortation>|</S.Sortation>
-              <S.MIddleText>일정 / 장소 추천</S.MIddleText>
-            </S.HorizontalContainer>
-
-          </S.VerticalContainer>
-
         </S.HorizontalContainer>
         <Link style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }} to='https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo.git' target="_blank">
           <img src={githubLogo} alt="github" style={{ margin: '0 1rem 0 0', width: '1.5rem' }} />

--- a/trizzle-front/src/components/KakaoMap/Map.type.ts
+++ b/trizzle-front/src/components/KakaoMap/Map.type.ts
@@ -48,7 +48,7 @@ export type PlaceList = {
 
 
 export type StaticMaspProps = {
-  center: string;
+  center: any;
   width: string;
   height: string;
 }

--- a/trizzle-front/src/components/KakaoMap/StaticMaps.tsx
+++ b/trizzle-front/src/components/KakaoMap/StaticMaps.tsx
@@ -1,26 +1,25 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { StaticMap } from "react-kakao-maps-sdk";
 import { StaticMaspProps } from './Map.type';
-import { koreaRegions } from "../../utils/Data/mapData";
 
 
 const StaticMaps: React.FC<StaticMaspProps> = (props: StaticMaspProps) => {
-    const regionCenter = koreaRegions.filter((region) => region.name === props.center)[0];
+  const placeCenter = { lat: props.center[1], lng: props.center[0] }
 
-    return (
-        <StaticMap // 지도를 표시할 Container
-            center={regionCenter.center}
-            style={{
-                // 지도의 크기
-                width: props.width,
-                height: props.height,
-                borderTopRightRadius: "1.5rem",
-                borderTopLeftRadius: "1.5rem",
-            }}
-            level={3} // 지도의 확대 레벨
-            marker={false}
-        />
-    )
+  return (
+    <StaticMap // 지도를 표시할 Container
+      center={placeCenter}
+      style={{
+        // 지도의 크기
+        width: props.width,
+        height: props.height,
+        borderTopRightRadius: "1.5rem",
+        borderTopLeftRadius: "1.5rem",
+      }}
+      level={3} // 지도의 확대 레벨
+      marker={false}
+    />
+  )
 }
 
 export default StaticMaps;

--- a/trizzle-front/src/components/Paging/index.tsx
+++ b/trizzle-front/src/components/Paging/index.tsx
@@ -70,6 +70,7 @@ const Paging: React.FC<PagingProps> = (props: PagingProps) => {
               startDate={item.plan.planStartDate}
               endDate={item.plan.planEndDate}
               region={item.plan.planLocation}
+              placeCenter={[item.plan.content[0].placeList[0].x, item.plan.content[0].placeList[0].y]}
               thema={item.plan.planThema}
               thumbnail={item.thumbnail?item.thumbnail:""}
               />

--- a/trizzle-front/src/components/PlanCard/PlanCard.type.ts
+++ b/trizzle-front/src/components/PlanCard/PlanCard.type.ts
@@ -4,6 +4,7 @@ export type PlanCardProps = {
   thumbnail: string;
   title: string;
   region: string;
+  placeCenter: any;
   startDate: string;
   endDate: string;
   likeCount: number;

--- a/trizzle-front/src/components/PlanCard/index.tsx
+++ b/trizzle-front/src/components/PlanCard/index.tsx
@@ -7,6 +7,7 @@ import { BsChatDots } from "react-icons/bs";
 import StaticMaps from "../KakaoMap/StaticMaps";
 
 const PlanCard: React.FC<PlanCardProps> = (props: PlanCardProps) => {
+  
   if (props.thema.length > 3) {
     props.thema.splice(3, props.thema.length - 3);
   }
@@ -14,7 +15,7 @@ const PlanCard: React.FC<PlanCardProps> = (props: PlanCardProps) => {
     <Link to={`/post/plan/${props.planId}`}>
       <S.Container>
         <S.Thumbnail >
-          {props.thumbnail === "" ?  <StaticMaps center={props.region} width="100%" height="17.5rem" /> : <S.ThumbnailImg src={props.thumbnail} />}
+          {props.thumbnail === "" ?  <StaticMaps center={props.placeCenter} width="100%" height="17.5rem" /> : <S.ThumbnailImg src={props.thumbnail} />}
 
           <S.SiteBadge>{props.region}</S.SiteBadge>
           <S.LikeContainer>

--- a/trizzle-front/src/pages/AddPostPlan/AddPostPlan.tsx
+++ b/trizzle-front/src/pages/AddPostPlan/AddPostPlan.tsx
@@ -42,8 +42,7 @@ const AddPostPlan: React.FC = () => {
       if (state.data.message === "update success" && state.data.reviewId) {
         // setData({ ...state.data, reviewId: state.data.reviewId });
       }
-      else if (!secret && state.data.message === "save success") navigate(`/post/plan/${state.data.postId}`);
-      else if (secret && state.data.message === "save success") navigate(`/post/plan/secret/${state.data.postId}`);
+      else if (state.data.message === "save success") navigate(`/post/plan/${state.data.postId}`);
       else setData(state.data);
     }
   }, [state]);
@@ -128,7 +127,7 @@ const AddPostPlan: React.FC = () => {
       const shouldProceed = window.confirm('게시하시면 다시 수정할 수 없습니다! 정말로 저장하시겠습니까?');
       if (shouldProceed) {
         const json = JSON.stringify(ResultData);
-        fetchData(`/api/posts`, 'Post', json);
+        fetchData(`/api/posts`, 'POST', json);
       }
     } else if (type === "secret") {
       setSecret(true);
@@ -141,7 +140,7 @@ const AddPostPlan: React.FC = () => {
       }
 
       const json = JSON.stringify(ResultData);
-      fetchData(`/api/posts`, 'Post', json);
+      fetchData(`/api/posts`, 'POST', json);
     }
   }
 

--- a/trizzle-front/src/pages/AddPostPlan/AddPostPlan.tsx
+++ b/trizzle-front/src/pages/AddPostPlan/AddPostPlan.tsx
@@ -26,6 +26,7 @@ const AddPostPlan: React.FC = () => {
   const [selectDay, setSelectDay] = useState<number>(0);
   const [file, setFile] = useState<File | null>(null);
   const [thumnail, setThumnail] = useState<string | null>(null);
+  const [placeCenter, setPlaceCenter] = useState<any>({ center: { lat: 0, lng: 0 } });
 
   const [isConnectPlaceModal, setIsConnectPlaceModal] = useState<boolean>(false);
   const [ConnectPlaceModalData, setConnectPlaceModalData] = useState<any>({});
@@ -67,6 +68,19 @@ const AddPostPlan: React.FC = () => {
       setSelectedDayPlan(newArray);
     }
   }, [selectDay, dayPlan]);
+
+  useEffect(() => {
+    if (selectedDayPlan !== null) {
+      const rePlace = selectedDayPlan[0].placeList;
+      if (rePlace.length !== 0) {
+        const newCenter = { center: { lat: rePlace[0].y, lng: rePlace[0].x } };
+        setPlaceCenter(newCenter);
+      } else {
+        const newCenter = { center: koreaRegions.filter((region) => { return region.name === regions })[0].center }
+        setPlaceCenter(newCenter);
+      }
+    }
+  }, [selectedDayPlan]);
 
   useEffect(() => {
     if (prevThema.length !== 0) {
@@ -272,17 +286,17 @@ const AddPostPlan: React.FC = () => {
         <S.HorizontalLine />
       </S.FormContainer>
 
-        <S.MapAndDayPlanContainer>
-          {data.content && <PlanMap selectDay={selectDay} setSelectDay={(day: number) => setSelectDay(day)} placeList={data.content} center={koreaRegions.filter((region) => { return region.name === regions })[0].center} page="detail" width="50%" />}
-          <S.DayPlanPostContainer>
-            <S.DayPlanPostInnerContainer>
-              <DayPlanPost planId={data.id} dayList={selectedDayPlan} selectDay={selectDay} onNewPostPlace={(day: number, data: any) => onPostPlace(day, data)} onConnetPostPlace={(day: number, data: any) => connectPlace(day, data)} />
-            </S.DayPlanPostInnerContainer>
-          </S.DayPlanPostContainer>
-        </S.MapAndDayPlanContainer>
-      
+      <S.MapAndDayPlanContainer>
+        {data.content && <PlanMap selectDay={selectDay} setSelectDay={(day: number) => setSelectDay(day)} placeList={data.content} center={placeCenter.center} page="detail" width="50%" />}
+        <S.DayPlanPostContainer>
+          <S.DayPlanPostInnerContainer>
+            <DayPlanPost planId={data.id} dayList={selectedDayPlan} selectDay={selectDay} onNewPostPlace={(day: number, data: any) => onPostPlace(day, data)} onConnetPostPlace={(day: number, data: any) => connectPlace(day, data)} />
+          </S.DayPlanPostInnerContainer>
+        </S.DayPlanPostContainer>
+      </S.MapAndDayPlanContainer>
+
       <div style={{ height: "10rem" }} />
-      
+
       {isConnectPlaceModal && <ConnectPlaceModal placeInfor={ConnectPlaceModalData} onclose={() => setIsConnectPlaceModal(!isConnectPlaceModal)} onClickedPlace={(place: any) => connectReview(place)} />}
     </Page >
   )

--- a/trizzle-front/src/pages/AddPostPlan/ModPostPlan.tsx
+++ b/trizzle-front/src/pages/AddPostPlan/ModPostPlan.tsx
@@ -26,6 +26,7 @@ const ModPostPlan: React.FC = () => {
   const [selectDay, setSelectDay] = useState<number>(0);
   const [file, setFile] = useState<File | null>(null);
   const [thumnail, setThumnail] = useState<string | null>(null);
+  const [placeCenter, setPlaceCenter] = useState<any>({ center: { lat: 0, lng: 0 } });
 
   const [isConnectPlaceModal, setIsConnectPlaceModal] = useState<boolean>(false);
   const [ConnectPlaceModalData, setConnectPlaceModalData] = useState<any>({});
@@ -67,6 +68,19 @@ const ModPostPlan: React.FC = () => {
       setSelectedDayPlan(newArray);
     }
   }, [selectDay, dayPlan]);
+
+  useEffect(() => {
+    if (selectedDayPlan !== null) {
+      const rePlace = selectedDayPlan[0].placeList;
+      if (rePlace.length !== 0) {
+        const newCenter = { center: { lat: rePlace[0].y, lng: rePlace[0].x } };
+        setPlaceCenter(newCenter);
+      } else {
+        const newCenter = { center: koreaRegions.filter((region) => { return region.name === regions })[0].center }
+        setPlaceCenter(newCenter);
+      }
+    }
+  }, [selectedDayPlan]);
 
   useEffect(() => {
     if (prevThema.length !== 0) {
@@ -278,7 +292,7 @@ const ModPostPlan: React.FC = () => {
       </S.FormContainer>
 
       <S.MapAndDayPlanContainer>
-        {dayPlan !== null && <PlanMap selectDay={selectDay} setSelectDay={(day: number) => setSelectDay(day)} placeList={dayPlan} center={koreaRegions.filter((region) => { return region.name === regions })[0].center} page="detail" width="50%" />}
+        {dayPlan !== null && <PlanMap selectDay={selectDay} setSelectDay={(day: number) => setSelectDay(day)} placeList={dayPlan} center={placeCenter.center} page="detail" width="50%" />}
         <S.DayPlanPostContainer>
           <S.DayPlanPostInnerContainer>
             <DayPlanPost planId={data.id} dayList={selectedDayPlan} selectDay={selectDay} onNewPostPlace={(day: number, data: any) => onPostPlace(day, data)} onConnetPostPlace={(day: number, data: any) => connectPlace(day, data)} />

--- a/trizzle-front/src/pages/Myfeed/index.tsx
+++ b/trizzle-front/src/pages/Myfeed/index.tsx
@@ -60,7 +60,8 @@ const Myfeed = () => {
           endDate={item.plan.planEndDate.slice(0,10)} 
           thumbnail={item.thumbnail? item.thumbnail : ""} 
           likeCount={item.likeCount? item.likeCount : 0} 
-          commentCount={item.commentCount? item.commentCount : 0} 
+          commentCount={item.commentCount? item.commentCount : 0}
+          placeCenter={[item.plan.content[0].placeList[0].x, item.plan.content[0].placeList[0].y]}
           planId={item.id} 
           thema={item.plan.planThema} 
           userId={item.accountId}/>

--- a/trizzle-front/src/pages/PostPlace/PostPlace.styles.tsx
+++ b/trizzle-front/src/pages/PostPlace/PostPlace.styles.tsx
@@ -86,7 +86,7 @@ export const InforFirstContainer = styled.div`
   position: relative;
   justify-content: space-between;
   align-items: center;
-  margin-top: 6rem;
+  margin-top: 7rem;
   margin-bottom: 1.5rem;
   font-size: 2rem;
   font-weight: bold;

--- a/trizzle-front/src/pages/PostPlace/PostPlace.tsx
+++ b/trizzle-front/src/pages/PostPlace/PostPlace.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { AiOutlineDown, AiOutlineUp } from "react-icons/ai";
 // import UseAnimations from "react-useanimations";
 // import star from 'react-useanimations/lib/star';
 import 'react-quill/dist/quill.snow.css';
@@ -17,7 +16,6 @@ import IconButton from "../../components/IconButton";
 export default function PostPlace() {
   const navigate = useNavigate();
   const [data, setData] = useState<any>(null);
-  const [isCommentOpen, setIsCommentOpen] = useState<boolean>(false);
   const [isLike, setIsLike] = useState<boolean>(false);
   const [isBookmark, setIsBookmark] = useState<boolean>(false);
   const [reviewUser, setReviewUser] = useState<any>(null);
@@ -69,7 +67,7 @@ export default function PostPlace() {
         <SearchBar type="normal" />
 
         <S.InforFirstContainer>
-          <div>제목 {data.reviewTitle}</div>
+          <div>{data.reviewTitle}</div>
           {isMe ?
             <>
               <Menu item={menuItems} />
@@ -147,23 +145,15 @@ export default function PostPlace() {
           <S.HorizontalFirstStartContainer>
             <S.CommentText>
               댓글
-              <S.CommentTextNumber>
-                {data.comments}
-              </S.CommentTextNumber>
-              {isCommentOpen ?
-                <AiOutlineUp size={"1rem"} onClick={() => setIsCommentOpen(!isCommentOpen)} />
-                :
-                <AiOutlineDown size={"1rem"} onClick={() => setIsCommentOpen(!isCommentOpen)} />
-              }
+              <S.CommentTextNumber>{data.comments}</S.CommentTextNumber>
             </S.CommentText>
             <S.CommentText>
               좋아요
               <IconButton icon="like" type="review" contentId={data.id} filled={isLike} />
             </S.CommentText>
           </S.HorizontalFirstStartContainer>
-          {isCommentOpen && (
-            <CommentSection page='review' postId={data.id} />
-          )}
+          <CommentSection page='review' postId={data.id} />
+
         </S.CommentContainer>
 
         {/* <S.RecommendContainer>

--- a/trizzle-front/src/pages/PostPlan/PostPlan.tsx
+++ b/trizzle-front/src/pages/PostPlan/PostPlan.tsx
@@ -27,6 +27,7 @@ const PostPlan: React.FC = () => {
   const [selectedDayPlan, setSelectedDayPlan] = useState<any>(null);
   const [planUser, setPlanUser] = useState<any>(null);
   const [isMe, setIsMe] = useState<boolean>(false);
+  const [placeCenter, setPlaceCenter] = useState<any>({ center: { lat: 0, lng: 0 } });
 
   const [isCommentOpen, setIsCommentOpen] = useState<boolean>(false);
   const [isLike, setIsLike] = useState<boolean>(false);
@@ -67,7 +68,6 @@ const PostPlan: React.FC = () => {
       setPlanUser(data.postUser);
       if (data.postUser.accountId === sessionStorage.getItem('accountId')) {
         setIsMe(true);
-
       }
       if (data.post.postSecret) {
         const NewArray = [...menuItems];
@@ -80,11 +80,21 @@ const PostPlan: React.FC = () => {
   useEffect(() => {
     if (selectDay === 0) {
       setSelectedDayPlan(dayPlan);
-    } else {
+    } else if (selectDay <= dayPlan.length) {
       const newArray = [dayPlan[selectDay - 1]];
       setSelectedDayPlan(newArray);
     }
   }, [selectDay]);
+
+  useEffect(() => {
+    if (selectedDayPlan !== null) {
+      const rePlace = selectedDayPlan[0].placeList;
+      if (rePlace.length !== 0) {
+        const newCenter = { center: { lat: rePlace[0].y, lng: rePlace[0].x } };
+        setPlaceCenter(newCenter);
+      }
+    }
+  }, [selectedDayPlan]);
 
   if (dayPlan !== null) {
     return (
@@ -126,8 +136,8 @@ const PostPlan: React.FC = () => {
               여행 테마
             </S.InforContainer>
             <S.Content>
-              {thema.map((thema: any) => (
-                <S.ThemaBadge key={thema.id}>{thema[0].name}</S.ThemaBadge>
+              {thema.map((thema: any, index: number) => (
+                <S.ThemaBadge key={index}>{thema[0].name}</S.ThemaBadge>
               ))}
             </S.Content>
           </S.HorizontalFirstStartContainer>
@@ -161,7 +171,7 @@ const PostPlan: React.FC = () => {
         </S.HorizontalContainer>
 
         <S.MapAndDayPlanContainer>
-          {dayPlan && <PlanMap selectDay={selectDay} setSelectDay={(day: number) => setSelectDay(day)} placeList={dayPlan} center={koreaRegions.filter((region) => { return region.name === regions })[0].center} page="detail" width="50%" />}
+          {dayPlan && <PlanMap selectDay={selectDay} setSelectDay={(day: number) => setSelectDay(day)} placeList={dayPlan} center={placeCenter.center} page="detail" width="50%" />}
           <S.DayPlanPostContainer>
             <S.DayPlanPostInnerContainer>
               <DayPlanPost type='post' dayList={selectedDayPlan} selectDay={selectDay} />

--- a/trizzle-front/src/pages/PostPlan/PostPlan.tsx
+++ b/trizzle-front/src/pages/PostPlan/PostPlan.tsx
@@ -2,10 +2,8 @@ import React, { useEffect, useState } from "react";
 
 import * as S from './PostPlan.styles';
 import Page from "../Page";
-import { AiOutlineDown, AiOutlineUp } from "react-icons/ai";
 import DayPlanPost from "../../shared/DayPlanPost/DayPlanPost";
 import PlanMap from "../../shared/PlanMap";
-import { koreaRegions } from "../../utils/Data/mapData";
 import UserPreview from "../../components/UserPreview";
 import { useAsync } from "../../utils/API/useAsync";
 import { useParams, useNavigate } from "react-router-dom";
@@ -14,6 +12,7 @@ import CommentSection from "../../shared/CommentSection";
 import SearchBar from "../../components/SearchBar";
 import IconButton from "../../components/IconButton";
 import Menu from "../../components/Menu";
+import { koreaRegions } from "../../utils/Data/mapData";
 
 const PostPlan: React.FC = () => {
   const [data, setData] = useState<any>(null);
@@ -29,7 +28,6 @@ const PostPlan: React.FC = () => {
   const [isMe, setIsMe] = useState<boolean>(false);
   const [placeCenter, setPlaceCenter] = useState<any>({ center: { lat: 0, lng: 0 } });
 
-  const [isCommentOpen, setIsCommentOpen] = useState<boolean>(false);
   const [isLike, setIsLike] = useState<boolean>(false);
   const [isBookmark, setIsBookmark] = useState<boolean>(false);
   const [menuItems, setMenuItems] = useState<any[]>([{
@@ -83,6 +81,7 @@ const PostPlan: React.FC = () => {
     } else if (selectDay <= dayPlan.length) {
       const newArray = [dayPlan[selectDay - 1]];
       setSelectedDayPlan(newArray);
+      console.log(newArray);
     }
   }, [selectDay]);
 
@@ -91,6 +90,9 @@ const PostPlan: React.FC = () => {
       const rePlace = selectedDayPlan[0].placeList;
       if (rePlace.length !== 0) {
         const newCenter = { center: { lat: rePlace[0].y, lng: rePlace[0].x } };
+        setPlaceCenter(newCenter);
+      } else {
+        const newCenter = { center: koreaRegions.filter((region) => { return region.name === regions })[0].center }
         setPlaceCenter(newCenter);
       }
     }
@@ -102,7 +104,7 @@ const PostPlan: React.FC = () => {
         <SearchBar type="normal" />
 
         <S.InforFirstContainer>
-          <div>제목 {title}</div>
+          <div>{title}</div>
           {isMe ?
             <>
               <Menu item={menuItems} />
@@ -185,23 +187,14 @@ const PostPlan: React.FC = () => {
           <S.HorizontalFirstStartContainer>
             <S.CommentText>
               댓글
-              <S.CommentTextNumber>
-
-              </S.CommentTextNumber>
-              {isCommentOpen ?
-                <AiOutlineUp size={"1rem"} onClick={() => setIsCommentOpen(!isCommentOpen)} />
-                :
-                <AiOutlineDown size={"1rem"} onClick={() => setIsCommentOpen(!isCommentOpen)} />
-              }
+              <S.CommentTextNumber></S.CommentTextNumber>
             </S.CommentText>
             <S.CommentText>
               좋아요
               <IconButton icon="like" type="post" filled={isLike} contentId={data.post.id} />
             </S.CommentText>
           </S.HorizontalFirstStartContainer>
-          {isCommentOpen && (
-            <CommentSection page='post' postId={data.id} />
-          )}
+          <CommentSection page='post' postId={data.id} />
         </S.CommentContainer>
 
         {/* <S.RecommendContainer>

--- a/trizzle-front/src/pages/SearchPlan/SearchPlan.tsx
+++ b/trizzle-front/src/pages/SearchPlan/SearchPlan.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import * as S from './SearchPlan.styles';
 import { useAsync } from "../../utils/API/useAsync";
-import {SearchLayout} from "../Page";
+import { SearchLayout } from "../Page";
 import PlanCard from "../../components/PlanCard";
 import DropdownMenu from "../../components/DropdownMenu";
 // import { tripThema } from "../../utils/Data/tripThema";
@@ -13,10 +13,10 @@ import DropdownMenu from "../../components/DropdownMenu";
 const SearchPlan = () => {
   const [allPlanList, setAllPlanList] = useState<any>(null);
   const [planList, setPlanList] = useState<any[]>([]);
-  const [sort, setSort] = useState<any>({name:"최신순", id: "new"});
+  const [sort, setSort] = useState<any>({ name: "최신순", id: "new" });
   // const [thema, setThema] = useState<any[]>([]);
   const [page, setPage] = useState<number>(0);
-  const [state, fetchData] = useAsync({url:`/api/posts/search?page=${page}&sort=${sort.id}`, method: 'GET'});
+  const [state, fetchData] = useAsync({ url: `/api/posts/search?page=${page}&sort=${sort.id}`, method: 'GET' });
 
   // const onThemaBadgeClick = (select: any) => {
   //   const itemExists = thema.some((item) => item.id === select.id);
@@ -36,68 +36,67 @@ const SearchPlan = () => {
 
     if (scrollTop + clientHeight === scrollHeight) {
       // 스크롤이 가장 아래로 내려갔을 때의 처리
-      if(allPlanList && allPlanList.pageable.last) return;
+      if (allPlanList && allPlanList.pageable.last) return;
       setPage((prevPage) => prevPage + 1);
     }
   };
 
   useEffect(() => {
-     // 스크롤 이벤트를 추가
+    // 스크롤 이벤트를 추가
     window.addEventListener("scroll", handleScroll);
     return () => {
-       // 컴포넌트가 언마운트될 때 이벤트 제거
+      // 컴포넌트가 언마운트될 때 이벤트 제거
       window.removeEventListener("scroll", handleScroll);
     };
   }, []);
 
   useEffect(() => {
     fetchData(`/api/posts/search?page=${page}&sort=${sort.id}`);
-  },[page]);
+  }, [page]);
 
   useEffect(() => {
     setPage(0);
   }, [sort]);
 
-
   useEffect(() => {
     if (state.data) {
-      if(page === 0) setPlanList(state.data.content);
-      else{
-      setPlanList((prev:any) => [...prev, ...state.data.content]);}
+      if (page === 0) setPlanList(state.data.content);
+      else {
+        setPlanList((prev: any) => [...prev, ...state.data.content]);
+      }
       setAllPlanList(state.data);
-      
+      console.log("gld:", state.data);
     }
   }, [state]);
 
-
-
-  if(allPlanList === null) return (<div>loading...</div>);
+  if (allPlanList === null) return (<div>loading...</div>);
   return (
     <SearchLayout selectTab="일정" >
       <S.SearchResultContainer>
-      <S.FilterContainer number={0}>
-        {allPlanList.totalElements} 개의 검색결과
-        <S.MenuContainer >
-          {/* <DropdownMenu type="search" name="여행 테마 필터" items={tripThema} selectedItem={thema}  onClick={(item:any) => onThemaBadgeClick(item)}/> */}
-          <DropdownMenu items={[{name: "최신순", id:"new"}, {name: "오래된순", id:"old"}, {name: "인기순", id:"like"}]} onClick={(item:any) => setSort(item)} name="정렬 기준" selectedItem={sort}/>
-          {/* <S.FilterButton onClick={onFilterClick}>
+        <S.FilterContainer number={0}>
+          {allPlanList.totalElements} 개의 검색결과
+          <S.MenuContainer >
+            {/* <DropdownMenu type="search" name="여행 테마 필터" items={tripThema} selectedItem={thema}  onClick={(item:any) => onThemaBadgeClick(item)}/> */}
+            <DropdownMenu items={[{ name: "최신순", id: "new" }, { name: "오래된순", id: "old" }, { name: "인기순", id: "like" }]} onClick={(item: any) => setSort(item)} name="정렬 기준" selectedItem={sort} />
+            {/* <S.FilterButton onClick={onFilterClick}>
             <IoIosSearch size="1.5rem" className="icon"/>
           </S.FilterButton> */}
-        </S.MenuContainer>
-      </S.FilterContainer>
+          </S.MenuContainer>
+        </S.FilterContainer>
         <S.PlanCardContainer>
-          {planList.length !== 0 && planList.map((plan:any, index:number) => (
+          {planList.length !== 0 && planList.map((plan: any, index: number) => (
             <PlanCard
               key={index}
               userId={plan.accountId}
               planId={plan.id}
-              thumbnail={plan.thumbnail?plan.thumbnail:""}
+              thumbnail={plan.thumbnail ? plan.thumbnail : ""}
               title={plan.postTitle}
               region={plan.plan.planLocation}
+              placeCenter={[plan.plan.content[0].placeList[0].x, plan.plan.content[0].placeList[0].y]}
               startDate={plan.plan.planStartDate}
               endDate={plan.plan.planEndDate}
-              likeCount={plan.likeCount===null?0:plan.likeCount}
-              commentCount={plan.commentCount?plan.commentCount:0}
+              likeCount={plan.likeCount === null ? 0 : plan.likeCount}
+              commentCount={plan.commentCount ? plan.commentCount : 0}
               thema={plan.plan.planThema} />
           ))}
         </S.PlanCardContainer>

--- a/trizzle-front/src/shared/ConnectPlaceModal/index.tsx
+++ b/trizzle-front/src/shared/ConnectPlaceModal/index.tsx
@@ -4,6 +4,7 @@ import * as S from './ConnectPlaceModal.styles';
 import Modal from "../../components/Modal";
 import { useAsync } from "../../utils/API/useAsync";
 import Paging from "../../components/Paging";
+import NullList from "../../components/NullList";
 
 type ConnectPlaceModalPorps = {
   placeInfor: any;
@@ -33,7 +34,7 @@ const ConnectPlaceModal: React.FC<ConnectPlaceModalPorps> = (props: ConnectPlace
     <Modal title="일정 불러오기" styleProps={{ width: "45rem", height: "28rem" }} onCloseClick={props.onclose}>
       <S.UploadModalContainer>
         {placeData.length === 0 ? (
-          <div>불러올 리뷰가 없습니다</div>
+          <NullList content="불러올 리뷰가 없습니다" />
         ) : (
           <Paging items={placeData} perPage={6} type="modalCommentPlace" onClickedData={(data: any) => clickedPlace(data)} />
         )}

--- a/trizzle-front/src/shared/DayPlanPost/DayPlanPost.styles.tsx
+++ b/trizzle-front/src/shared/DayPlanPost/DayPlanPost.styles.tsx
@@ -26,6 +26,21 @@ ${(props) => props.type ? 'display: flex; justify-content: center; align-items: 
   border-radius: 1rem;
 `
 
+export const KeywordContainer = styled.div<{ type?: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+export const KeywordAddress = styled.div`
+  width: 5rem;
+  max-width: 100%;
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: #5B5B5B;
+  white-space: pre-line;
+`
+
 export const PlaceAddress = styled.div`
   width: 100%;
   max-width: 100%;
@@ -112,10 +127,8 @@ export const PlaceImage = styled.img`
   width: 30%;
   height: 100%;
   background-color: #FFECAA;
-  border-top-left-radius: 0.75rem;
-  border-bottom-left-radius: 0.75rem;
-  position: relative;
-  top: -1.2rem;
+  border-top-left-radius: 0.9rem;
+  border-bottom-left-radius: 0.9rem;
 `
 
 export const PlaceInfo = styled.div`

--- a/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
+++ b/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
@@ -8,6 +8,7 @@ import res from "src/assets/keywords/trans.svg"
 import trans from "../../assets/keywords/trans.svg"
 import rest from "../../assets/keywords/rest.svg"
 import shopping from "../../assets/keywords/shopping.svg"
+import NullList from "../../components/NullList";
 
 type DayPlanPostProps = {
   type?: string;
@@ -36,6 +37,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
   }
 
   useEffect(() => {
+    console.log("컴온", props.dayList[0].placeList);
     setData(props.dayList);
   }, [props.dayList]);
 
@@ -60,11 +62,76 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                 <S.DayContainer key={index}>
                   {plans.day}일차
                 </S.DayContainer>
-                {plans.placeList.map((place: any, innerIndex: number) => (
-                  <div key={innerIndex}>
-                    {place.review && place.review !== null ? (
-                      <Link to={`/post/places/${place.review.id}`} target="_blank">
-                        <S.PlacePostContainer>
+                {plans.placeList.length === 0 ? (
+                  <NullList content="공유된 일정이 없습니다" />
+                ) : (
+                  plans.placeList.map((place: any, innerIndex: number) => (
+                    <div key={innerIndex}>
+                      {place.review && place.review !== null ? (
+                        <Link to={`/post/places/${place.review.id}`} target="_blank">
+                          <S.PlacePostContainer>
+                            <div style={{ width: '100%', height: '100%' }}>
+                              {
+                                place.review.thumbnail === '' ?
+                                  <S.PlaceLogo>
+                                    <img src={logo} alt="logo" style={{ width: "2.2rem", height: "auto" }} />
+                                  </S.PlaceLogo>
+                                  :
+                                  <S.PlaceImage src={place.review.thumbnail} alt="image" />
+                              }
+                              <S.PlaceInfo>
+                                <S.PlaceName>{place.review.reviewTitle}</S.PlaceName>
+                                <S.PlacePostName>{place.review.place.placeName}</S.PlacePostName>
+                              </S.PlaceInfo>
+                            </div>
+                          </S.PlacePostContainer>
+                        </Link>
+                      ) : (
+                        place.keyword !== null ? (
+                          <S.PlaceContainer key={innerIndex} type={true}>
+                            <div style={{ width: '100%', height: '100%' }}>
+                              <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
+                              <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.PlaceAddress>
+                            </div>
+                          </S.PlaceContainer>
+                        ) : (
+                          <S.PlaceContainer key={innerIndex} >
+                            <div style={{ width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                              <S.PalceText>
+                                {place.placeName}
+                              </S.PalceText>
+                            </div>
+                          </S.PlaceContainer>
+                        )
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            ))}
+          </>
+        )
+      }
+    default:
+      if (!(data && data.length)) {
+        return (
+          <div>정해진 일정이 없습니다.</div>
+        )
+      } else {
+        return (
+          <>
+            {data.map((plans: any, index: number) => (
+              <div key={index}>
+                <S.DayContainer>
+                  {plans.day}일차
+                </S.DayContainer>
+                {plans.placeList.length === 0 ? (
+                  <NullList content="공유된 일정이 없습니다" />
+                ) : (
+                  plans.placeList.map((place: any, innerIndex: number) =>
+                    <div key={innerIndex}>
+                      {place.review && place.review !== null ? (
+                        <S.PlacePostNoneContainer>
                           <div style={{ width: '100%', height: '100%' }}>
                             {
                               place.review.thumbnail === '' ?
@@ -79,99 +146,8 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                               <S.PlacePostName>{place.review.place.placeName}</S.PlacePostName>
                             </S.PlaceInfo>
                           </div>
-                        </S.PlacePostContainer>
-                      </Link>
-                    ) : (
-                      place.keyword !== null ? (
-                        <S.PlaceContainer key={innerIndex} type={true}>
-                          <div style={{ width: '100%', height: '100%' }}>
-                            <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
-                            <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.PlaceAddress>
-                          </div>
-                        </S.PlaceContainer>
-                      ) : (
-                        <S.PlaceContainer key={innerIndex} >
-                          <div style={{ width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-                            <S.PalceText>
-                              {place.placeName}
-                            </S.PalceText>
-                          </div>
-                        </S.PlaceContainer>
-                      )
-                    )}
-                  </div>
-                ))}
-              </div>
-            ))
-            }
-          </>
-        )
-      }
-    default:
-      if (!(data && data.length)) {
-        return (
-          <div>정해진 일정이 없습니다.</div>
-        )
-      } else {
-        return (
-          <div key={index}>
-            {data.map((plans: any, index: number) => (
-              <div key={index}>
-                <S.DayContainer>
-                  {plans.day}일차
-                </S.DayContainer>
-                {plans.placeList.map((place: any, innerIndex: number) =>
-                  <div key={innerIndex}>
-                    {place.review && place.review !== null ? (
-                      <S.PlacePostNoneContainer>
-                        <div style={{ width: '100%', height: '100%' }}>
-                          {
-                            place.review.thumbnail === '' ?
-                              <S.PlaceLogo>
-                                <img src={logo} alt="logo" style={{ width: "2.2rem", height: "auto" }} />
-                              </S.PlaceLogo>
-                              :
-                              <S.PlaceImage src={place.review.thumbnail} alt="image" />
-                          }
-                          <S.PlaceInfo>
-                            <S.PlaceName>{place.review.reviewTitle}</S.PlaceName>
-                            <S.PlacePostName>{place.review.place.placeName}</S.PlacePostName>
-                          </S.PlaceInfo>
-                        </div>
-                        <S.ModifyButton onClick={() => openAndCloseDetail(index, innerIndex)}>
-                          수정
-                          {isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
-                            <S.ToggleButtonContainer>
-                              <S.ToggleButtonOption onClick={() => {
-                                if (props.onNewPostPlace) {
-                                  props.onNewPostPlace(plans.day, data[index].placeList[innerIndex]);
-                                  openAndCloseDetail(index, innerIndex);
-                                }
-                              }}>
-                                새 리뷰 작성
-                              </S.ToggleButtonOption>
-                              <S.ToggleButtonOption onClick={() => {
-                                if (props.onConnetPostPlace) {
-                                  props.onConnetPostPlace(plans.day, data[index].placeList[innerIndex]);
-                                  openAndCloseDetail(index, innerIndex);
-                                }
-                              }}>
-                                리뷰 불러오기
-                              </S.ToggleButtonOption>
-                            </S.ToggleButtonContainer>
-                          }
-                        </S.ModifyButton>
-                      </S.PlacePostNoneContainer>
-                    ) : (
-                      place.keyword !== null ? (
-                        <S.KeywordContainer key={innerIndex} type={true}>
-                          <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
-                          <S.KeywordAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.KeywordAddress>
-                        </S.KeywordContainer>
-                      ) : (
-                        <S.PlaceContainer key={innerIndex} >
-                          <S.ThreeDotsButton onClick={() => openAndCloseDetail(index, innerIndex)}>
-                            <PiDotsThree size={25} />
+                          <S.ModifyButton onClick={() => openAndCloseDetail(index, innerIndex)}>
+                            수정
                             {isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
                               <S.ToggleButtonContainer>
                                 <S.ToggleButtonOption onClick={() => {
@@ -192,21 +168,53 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                                 </S.ToggleButtonOption>
                               </S.ToggleButtonContainer>
                             }
-                          </S.ThreeDotsButton>
-                          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-                            <S.PalceText>
-                              {place.placeName}
-                            </S.PalceText>
-                          </div>
-                        </S.PlaceContainer>
-                      )
-                    )}
-                  </div >
+                          </S.ModifyButton>
+                        </S.PlacePostNoneContainer>
+                      ) : (
+                        place.keyword !== null ? (
+                          <S.KeywordContainer key={innerIndex} type={true}>
+                            <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
+                            <S.KeywordAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.KeywordAddress>
+                          </S.KeywordContainer>
+                        ) : (
+                          <S.PlaceContainer key={innerIndex} >
+                            <S.ThreeDotsButton onClick={() => openAndCloseDetail(index, innerIndex)}>
+                              <PiDotsThree size={25} />
+                              {isDdetailOpen[index] && isDdetailOpen[index][innerIndex] &&
+                                <S.ToggleButtonContainer>
+                                  <S.ToggleButtonOption onClick={() => {
+                                    if (props.onNewPostPlace) {
+                                      props.onNewPostPlace(plans.day, data[index].placeList[innerIndex]);
+                                      openAndCloseDetail(index, innerIndex);
+                                    }
+                                  }}>
+                                    새 리뷰 작성
+                                  </S.ToggleButtonOption>
+                                  <S.ToggleButtonOption onClick={() => {
+                                    if (props.onConnetPostPlace) {
+                                      props.onConnetPostPlace(plans.day, data[index].placeList[innerIndex]);
+                                      openAndCloseDetail(index, innerIndex);
+                                    }
+                                  }}>
+                                    리뷰 불러오기
+                                  </S.ToggleButtonOption>
+                                </S.ToggleButtonContainer>
+                              }
+                            </S.ThreeDotsButton>
+                            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                              <S.PalceText>
+                                {place.placeName}
+                              </S.PalceText>
+                            </div>
+                          </S.PlaceContainer>
+                        )
+                      )}
+                    </div>
+                  )
                 )}
               </div>
-            ))
-            }
-          </div>
+            ))}
+          </>
         )
       }
   }

--- a/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
+++ b/trizzle-front/src/shared/DayPlanPost/DayPlanPost.tsx
@@ -56,7 +56,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
         return (
           <>
             {data.map((plans: any, index: number) => (
-              <>
+              <div key={index}>
                 <S.DayContainer key={index}>
                   {plans.day}일차
                 </S.DayContainer>
@@ -101,7 +101,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                     )}
                   </div>
                 ))}
-              </>
+              </div>
             ))
             }
           </>
@@ -114,7 +114,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
         )
       } else {
         return (
-          <>
+          <div key={index}>
             {data.map((plans: any, index: number) => (
               <div key={index}>
                 <S.DayContainer>
@@ -164,12 +164,10 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
                       </S.PlacePostNoneContainer>
                     ) : (
                       place.keyword !== null ? (
-                        <S.PlaceContainer key={innerIndex} type={true}>
-                          <div>
-                            <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
-                            <S.PlaceAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.PlaceAddress>
-                          </div>
-                        </S.PlaceContainer>
+                        <S.KeywordContainer key={innerIndex} type={true}>
+                          <img src={KeywordList.filter((item) => item.keyword === place.keyword)[0].src} alt="keywordImg" style={{ width: "4rem", height: "auto" }} />
+                          <S.KeywordAddress style={{ width: "auto", marginLeft: "0.4rem" }}>{place.keyword}</S.KeywordAddress>
+                        </S.KeywordContainer>
                       ) : (
                         <S.PlaceContainer key={innerIndex} >
                           <S.ThreeDotsButton onClick={() => openAndCloseDetail(index, innerIndex)}>
@@ -208,7 +206,7 @@ const DayPlanPost: React.FC<DayPlanPostProps> = (props: DayPlanPostProps) => {
               </div>
             ))
             }
-          </>
+          </div>
         )
       }
   }

--- a/trizzle-front/src/shared/UploadPlanModal/index.tsx
+++ b/trizzle-front/src/shared/UploadPlanModal/index.tsx
@@ -4,6 +4,7 @@ import * as S from './UploadPlanModal.styles'
 import Modal from "../../components/Modal";
 import { useAsync } from "../../utils/API/useAsync";
 import Paging from "../../components/Paging";
+import NullList from "../../components/NullList";
 
 type ScretDropdownPorps = {
   onclose: () => void;
@@ -32,7 +33,7 @@ const UploadPlanModal: React.FC<ScretDropdownPorps> = (props: ScretDropdownPorps
     <Modal title="일정 불러오기" styleProps={{ width: "45rem", height: "28rem" }} onCloseClick={props.onclose}>
       <S.UploadModalContainer>
         {planData.length === 0 ? (
-          <div>불러올 일정이 없습니다</div>
+          <NullList content="불러올 일정이 없습니다" />
         ) : (
           <Paging items={planData} perPage={6} type="modalCommentPlan" onClickedData={(data: any) => clickedPlace(data)} />
         )}


### PR DESCRIPTION
## 관련 이슈
- #42
- #5

## 구현 기능
- 불러올 일정 / 리뷰 없을 시 모달에 띄우는 문구 추가
- 일정 게시글(수정, 확인) 지도 center 현재 보이는 일정의 첫 번째 장소 위치로 선정, 일정 없을 시 선택 지역 center로 위치 대체
- 일정 검색 컴포넌트 썸네일 정적 지도 사용자 일정 장소로 위치 지정
- 일정 게시글에 일차별 장소가 없을 시 "공유된 일정 없음" 컴포넌트 추가
- 일정 장소 컴포넌트 스타일 수정
- 일정 / 리뷰 게시글 댓글 펼치기 제거, 제목 margin 수정
- footer 내용 수정

- 정적지도(placeCenter={[y, x]} 속성 추가)
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/127061457/0ed20477-1fcc-48b6-a655-c6c57a424dc0)
