### PR TITLE
[ADD] 일정 복사 기능 추가 및 마이피드 일정 게시글 썸네일 정적지도 Center 문제 해결

### DIFF
--- a/trizzle-front/src/components/Headers/index.tsx
+++ b/trizzle-front/src/components/Headers/index.tsx
@@ -40,7 +40,7 @@ const Headers: React.FC<HeadersProps> = (props: HeadersProps) => {
       else {
         setIsLogin(true);
         setUserData(state.data);
-        setNotiCount(state.data.noti.length);
+        setNotiCount(state.data.noti?.length || 0);
         sessionStorage.setItem("accountId", state.data.id);
         sessionStorage.setItem("profileImg", state.data.profileImg);
       }

--- a/trizzle-front/src/components/KakaoMap/StaticMaps.tsx
+++ b/trizzle-front/src/components/KakaoMap/StaticMaps.tsx
@@ -9,7 +9,7 @@ const StaticMaps: React.FC<StaticMaspProps> = (props: StaticMaspProps) => {
 
   useEffect(() => {
     if (typeof props.center === "string") {
-      setPlaceCenter(koreaRegions.filter((region) => {return region.name === props.center })[0].center)
+      setPlaceCenter(koreaRegions.filter((region) => {return region.name === props.center })[0].center);
     } else {
       setPlaceCenter({ lat: props.center[1], lng: props.center[0] });
     }

--- a/trizzle-front/src/pages/AddPostPlan/AddPostPlanOpen.tsx
+++ b/trizzle-front/src/pages/AddPostPlan/AddPostPlanOpen.tsx
@@ -171,7 +171,7 @@ const AddPostPlanOpen: React.FC = () => {
         </S.UploadContainer>
         
       <div style={{ height: "10rem" }} />
-      {isUploadPlanModal && <UploadPlanModal onclose={() => setIsUploadPlanModal(!isUploadPlanModal)} onClickedPlan={(plan: any) => uploadPlanData(plan)} />}
+      {isUploadPlanModal && <UploadPlanModal title="일정 불러오기" onclose={() => setIsUploadPlanModal(!isUploadPlanModal)} onClickedPlan={(plan: any) => uploadPlanData(plan)} />}
     </Page >
   )
 }

--- a/trizzle-front/src/pages/Myfeed/index.tsx
+++ b/trizzle-front/src/pages/Myfeed/index.tsx
@@ -63,7 +63,7 @@ const Myfeed = () => {
           thumbnail={item.thumbnail? item.thumbnail : ""} 
           likeCount={item.likeCount? item.likeCount : 0} 
           commentCount={item.commentCount? item.commentCount : 0}
-          placeCenter={[item.plan.content[0].placeList[0].x, item.plan.content[0].placeList[0].y]}
+          placeCenter={item.plan.content[0].placeList[0].keyword === null ? [item.plan.content[0].placeList[0].x, item.plan.content[0].placeList[0].y] : item.plan.planLocation}
           planId={item.id} 
           thema={item.plan.planThema} 
           userId={item.accountId}/>

--- a/trizzle-front/src/pages/PostPlan/PostPlan.styles.tsx
+++ b/trizzle-front/src/pages/PostPlan/PostPlan.styles.tsx
@@ -113,7 +113,7 @@ export const DayPlanPostContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-end;
   width: 45%;
   height: 34rem;
   border: 2px solid #FFDC61;
@@ -214,4 +214,17 @@ export const RecommendContainer = styled.div`
 export const RecommendText = styled.div`
   font-size: 2.5rem;
   font-weight: bold;
+`
+
+export const CopyPlan = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 1rem 0.5rem 0;
+`
+
+export const CopyPlanText = styled.button`
+  margin: 0 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 400;
 `

--- a/trizzle-front/src/pages/PostPlan/PostPlan.styles.tsx
+++ b/trizzle-front/src/pages/PostPlan/PostPlan.styles.tsx
@@ -216,11 +216,26 @@ export const RecommendText = styled.div`
   font-weight: bold;
 `
 
+export const CopyPlanContainer = styled.button`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`
+
+export const FlexEndContainer = styled.button`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+`
+
 export const CopyPlan = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 0 1rem 0.5rem 0;
+  margin: 0 0.5rem 0;
 `
 
 export const CopyPlanText = styled.button`

--- a/trizzle-front/src/pages/PostPlan/PostPlan.tsx
+++ b/trizzle-front/src/pages/PostPlan/PostPlan.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { LuCopyPlus } from "react-icons/lu";
+import { IoArrowBackOutline } from "react-icons/io5";
 import * as S from './PostPlan.styles';
 import Page from "../Page";
 import DayPlanPost from "../../shared/DayPlanPost/DayPlanPost";
@@ -30,6 +31,7 @@ const PostPlan: React.FC = () => {
   const [likeCount, setLikeCount] = useState<number>(0);
   const [bookmarkCount, setBookmarkCount] = useState<number>(0);
   const [isCopyPlan, setIsCopyPlan] = useState<boolean>(false);
+  const [isCopyPlanModal, setIsCopyPlanModal] = useState<boolean>(false);
   const [placeCenter, setPlaceCenter] = useState<any>({ center: { lat: 0, lng: 0 } });
 
   const [isLike, setIsLike] = useState<boolean>(false);
@@ -52,7 +54,7 @@ const PostPlan: React.FC = () => {
       if (state.data.message && state.data.message === "delete success") navigate("/myfeed");
       if (state.data.message && state.data.message === "save success") {
         const response = window.confirm("일정을 복사한 내 일정으로 이동하시겠습니까?");
-        if (response) navigate(`/myfeed/plans/${state.data.planId}`)
+        if (response) navigate(`/myfeed/plans`)
       }
       else setData(state.data);
     }
@@ -60,8 +62,7 @@ const PostPlan: React.FC = () => {
 
   useEffect(() => {
     if (data !== null) {
-      console.log(data);
-      setTitle(data.post.plan.planName);
+      setTitle(data.post.postTitle);
       setStartDate(data.post.plan.planStartDate);
       setEndDate(data.post.plan.planEndDate);
       setRegions(data.post.plan.planLocation);
@@ -85,6 +86,7 @@ const PostPlan: React.FC = () => {
   }, [data]);
 
   useEffect(() => {
+    setIsCopyPlan(false);
     if (selectDay === 0) {
       setSelectedDayPlan(dayPlan);
     } else if (selectDay <= dayPlan.length) {
@@ -118,6 +120,16 @@ const PostPlan: React.FC = () => {
     });
     const json = JSON.stringify(newPlan);
     fetchData(`/api/plans/${newPlan.id}`, 'PUT', json);
+  }
+
+  const copyNewPlanData = () => {
+    const newData = { ...data.post.plan };
+    delete newData.id;
+    delete newData.accountId;
+    delete newData.planRegistrationDate;
+    newData.planName = data.post.postTitle + "_복사본";
+    const json = JSON.stringify(newData);
+    fetchData(`/api/plans`, "POST", json);
   }
 
   if (dayPlan !== null) {
@@ -196,17 +208,41 @@ const PostPlan: React.FC = () => {
             />
           )}
           <S.DayPlanPostContainer>
-            {selectDay === 0 ?
+            {selectDay === 0 ? (isCopyPlan ?
+              <S.CopyPlanContainer>
+                <IoArrowBackOutline onClick={() => setIsCopyPlan(!isCopyPlan)} />
+                <S.FlexEndContainer>
+                  <S.CopyPlan onClick={copyNewPlanData} >
+                    <S.CopyPlanText>새 일정으로 추가</S.CopyPlanText>
+                  </S.CopyPlan>
+                  <S.CopyPlan onClick={() => setIsCopyPlanModal(!isCopyPlanModal)} >
+                    <S.CopyPlanText> 기존 일정에 복사</S.CopyPlanText>
+                  </S.CopyPlan>
+                </S.FlexEndContainer>
+              </S.CopyPlanContainer>
+              :
               <S.CopyPlan onClick={() => setIsCopyPlan(!isCopyPlan)} >
                 <LuCopyPlus />
                 <S.CopyPlanText>전체일정복사</S.CopyPlanText>
               </S.CopyPlan>
+            ) : (isCopyPlan ?
+              <S.CopyPlanContainer>
+                <IoArrowBackOutline onClick={() => setIsCopyPlan(!isCopyPlan)} />
+                <S.FlexEndContainer>
+                  <S.CopyPlan onClick={copyNewPlanData} >
+                    <S.CopyPlanText>새 일정 추가</S.CopyPlanText>
+                  </S.CopyPlan>
+                  <S.CopyPlan onClick={() => setIsCopyPlanModal(!isCopyPlanModal)} >
+                    <S.CopyPlanText> 기존 일정에 복사</S.CopyPlanText>
+                  </S.CopyPlan>
+                </S.FlexEndContainer>
+              </S.CopyPlanContainer>
               :
               <S.CopyPlan onClick={() => setIsCopyPlan(!isCopyPlan)} >
                 <LuCopyPlus />
                 <S.CopyPlanText>{selectDay}일차 일정복사</S.CopyPlanText>
               </S.CopyPlan>
-            }
+            )}
             <S.DayPlanPostInnerContainer>
               <DayPlanPost
                 type="post"
@@ -215,7 +251,7 @@ const PostPlan: React.FC = () => {
               />
             </S.DayPlanPostInnerContainer>
           </S.DayPlanPostContainer>
-        </S.MapAndDayPlanContainer>
+        </S.MapAndDayPlanContainer >
 
         <UserPreview
           accountId={planUser.accountId}
@@ -243,14 +279,13 @@ const PostPlan: React.FC = () => {
           </S.HorizontalFirstStartContainer>
           <CommentSection page="post" postId={data.post.id} />
         </S.CommentContainer>
-        {isCopyPlan && <UploadPlanModal title="추가할 일정" onclose={() => setIsCopyPlan(!isCopyPlan)} onClickedPlan={(plan: any[]) => copyPlanData(plan)} />}
-
+        {isCopyPlanModal && <UploadPlanModal title="추가할 일정" onclose={() => setIsCopyPlanModal(!isCopyPlanModal)} onClickedPlan={(plan: any[]) => copyPlanData(plan)} />}
         {/* <S.RecommendContainer>
         <S.RecommendText>
           &#123;검색결과&#125;에 대한 다른 장소 추천 결과 입니다.
         </S.RecommendText>
       </S.RecommendContainer> */}
-      </Page>
+      </Page >
     );
   }
 }

--- a/trizzle-front/src/shared/DayPlan/DayPlace.tsx
+++ b/trizzle-front/src/shared/DayPlan/DayPlace.tsx
@@ -62,7 +62,7 @@ const DayPlace: React.FC<DayPlaceProps> = (props: DayPlaceProps) => {
   }, [props.place, props.day, props.index, props.onDeleteClick, props.isPlan, props.isPost, props.id]);
 
 
-  if (props.place.hasOwnProperty('placeName')) {
+  if (props.place.hasOwnProperty('placeName') && props.place.placeName !== null) {
     return (
       <S.PlaceContainer>
         {menuItem.length !== 0 &&

--- a/trizzle-front/src/shared/UploadPlanModal/index.tsx
+++ b/trizzle-front/src/shared/UploadPlanModal/index.tsx
@@ -7,6 +7,7 @@ import Paging from "../../components/Paging";
 import NullList from "../../components/NullList";
 
 type ScretDropdownPorps = {
+  title: string;
   onclose: () => void;
   onClickedPlan: (value: any) => void;
 }
@@ -31,7 +32,7 @@ const UploadPlanModal: React.FC<ScretDropdownPorps> = (props: ScretDropdownPorps
   }
 
   return (
-    <Modal title="일정 불러오기" styleProps={{ width: "45rem", height: "28rem" }} onCloseClick={props.onclose}>
+    <Modal title={props.title} styleProps={{ width: "45rem", height: "28rem" }} onCloseClick={props.onclose}>
       <S.UploadModalContainer>
         {planData.length === 0 ? (
           <NullList content="불러올 일정이 없습니다" />


### PR DESCRIPTION
## 관련 이슈
- #42
- #16 

## 구현 기능
- 일정 복사 기능 추가(사용자 일차 선택 시 부분 일정 복사 가능)
- 일정 썸네일 정적지도 center 문제 해결

## 스크린샷
- 일정 복사 기능 추가
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/127061457/f041a4e5-7dd2-43d9-97dc-e112cb3050c0)
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/127061457/ec3152e9-b124-4957-b0f4-96ad9d5a6b7d)

- 일정 썸네일 정적지도 center 문제 해결
![image](https://github.com/CSID-DGU/2023-2-SCS4031-02-CoCo/assets/127061457/00f2d6b8-13ab-4af1-aec8-4da9acc82a8c)

## reviews
- 본인이 작성한 일정 게시글도 일정 복사가 가능하게 할 지에 대한 논의 필요