### PR TITLE
[FEAT] 삭제 오류 수정 및 review연동 방식 변경(api추가)

### DIFF
--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import trizzle.trizzlebackend.Utils.JwtUtil;
 import trizzle.trizzlebackend.domain.ElasticPost;
 import trizzle.trizzlebackend.domain.ElasticReview;
+import trizzle.trizzlebackend.domain.Plan;
 import trizzle.trizzlebackend.domain.Review;
 import trizzle.trizzlebackend.dto.response.ReviewDto;
 import trizzle.trizzlebackend.service.ReviewService;
@@ -149,5 +150,18 @@ public class ReviewController {
         List<Review> reviews = reviewService.findReviewsWithPlaceId(placeId);
 
         return ResponseEntity.ok(reviews);
+    }
+
+    /*review 연동*/
+    @PutMapping("/connect/{reviewId}")
+    public ResponseEntity reviewConnect(@PathVariable("reviewId") String reviewId, @RequestBody Plan plan, HttpServletRequest request) {
+        String token = JwtUtil.getAccessTokenFromCookie(request);
+        String accountId = JwtUtil.getAccountId(token, secretKey);
+
+
+        String message = reviewService.reviewConnect(plan, reviewId, accountId);
+
+        return ResponseEntity.ok()
+                .body("{\"message\": \"" + message + "\"}");
     }
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
@@ -164,4 +164,16 @@ public class ReviewController {
         return ResponseEntity.ok()
                 .body("{\"message\": \"" + message + "\"}");
     }
+
+    @PutMapping("/disconnect/{reviewId}")
+    public ResponseEntity reviewDisconnect(@PathVariable("reviewId") String reviewId, @RequestBody Plan plan, HttpServletRequest request) {
+        String token = JwtUtil.getAccessTokenFromCookie(request);
+        String accountId = JwtUtil.getAccountId(token, secretKey);
+
+
+        String message = reviewService.reviewDisconnect(plan, reviewId, accountId);
+
+        return ResponseEntity.ok()
+                .body("{\"message\": \"" + message + "\"}");
+    }
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/controller/ReviewController.java
@@ -109,7 +109,7 @@ public class ReviewController {
         Review review = reviewService.checkMyReview(reviewId, accountId);
 
         if (review != null) {
-            reviewService.deleteReview(reviewId);
+            reviewService.deleteReview(reviewId, accountId);
             String message = "delete success";
             List<Review> myReviews = reviewService.findMyReviews(accountId);
 

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/BookmarkRepository.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/BookmarkRepository.java
@@ -10,4 +10,6 @@ public interface BookmarkRepository extends MongoRepository<Bookmark, String> {
     List<Bookmark> findByAccountIdAndType(String accountId, String type);
 
     List<Bookmark> findByPostId(String postId);
+
+    List<Bookmark> findByReviewId(String reviewId);
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/BookmarkRepository.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/BookmarkRepository.java
@@ -8,4 +8,6 @@ public interface BookmarkRepository extends MongoRepository<Bookmark, String> {
     Bookmark findByPostIdAndAccountId(String postId, String accountId);
     Bookmark findByReviewIdAndAccountId(String reviewId, String accountId);
     List<Bookmark> findByAccountIdAndType(String accountId, String type);
+
+    List<Bookmark> findByPostId(String postId);
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/LikeRepository.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/LikeRepository.java
@@ -13,4 +13,6 @@ public interface LikeRepository extends MongoRepository<Like, String> {
     List<Like> findByTypeAndCommentId(String type, String commentId);
 
     List<Like> findByPostId(String postId);
+
+    List<Like> findByReviewId(String reviewId);
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/LikeRepository.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/LikeRepository.java
@@ -11,4 +11,6 @@ public interface LikeRepository extends MongoRepository<Like, String> {
     Like findByCommentIdAndAccountId(String commentId, String accountId);
 
     List<Like> findByTypeAndCommentId(String type, String commentId);
+
+    List<Like> findByPostId(String postId);
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/PlanRepository.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/repository/PlanRepository.java
@@ -14,4 +14,6 @@ public interface PlanRepository extends MongoRepository<Plan, String> {
 
     Plan findByAccountIdAndPostId(String accountId, String postId);
 
+    Plan findByIdAndAccountId(String id, String accountId);
+
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/CommentService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/CommentService.java
@@ -109,10 +109,7 @@ public class CommentService {
         }
         notificationService.deleteNotification(comment.getId());
         //좋아요 테이블에서 해당 댓글에 좋아요 누른거 모두 삭제 로직
-        List<Like> likes = likeRepository.findByTypeAndCommentId("comment", comment.getId());
-        for (Like like : likes) {
-            likeRepository.delete(like);
-        }
+        deleteLikesByCommentId(comment.getId());
         return commentRepository.save(comment);
     };
 
@@ -212,6 +209,16 @@ public class CommentService {
     public Comment findComment(String id) {
         Optional<Comment> optionalComment = commentRepository.findById(id);
         return optionalComment.orElse(null);
+    }
+
+    /*댓글의 좋아요 삭제*/
+    private void deleteLikesByCommentId(String commentId) {
+        List<Like> likes = likeRepository.findByTypeAndCommentId("comment", commentId);
+        if (likes != null) {
+            for (Like like : likes) {
+                likeRepository.delete(like);
+            }
+        }
     }
 
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/LikeService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/LikeService.java
@@ -11,6 +11,7 @@ import trizzle.trizzlebackend.repository.PostRepository;
 import trizzle.trizzlebackend.repository.ReviewRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -142,4 +143,7 @@ public class LikeService {
         }
 
     }
+
+
+
 }

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/ReviewService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/ReviewService.java
@@ -229,6 +229,28 @@ public class ReviewService {
         return reviews;
     }
 
+    public String reviewConnect(Plan plan, String reviewId, String accountId) {
+        /*review 연동 된 것 plan에 반영*/
+        Plan existingPlan = planRepository.findByIdAndAccountId(plan.getId(), accountId);
+        if (existingPlan != null) {
+            existingPlan.setContent(plan.getContent());
+            planRepository.save(existingPlan);
+
+            /* review에 planId 추가*/
+            Review review = reviewRepository.findByIdAndAccountId(reviewId, accountId);
+            if (review != null) {
+                review.setPlanId(existingPlan.getId());
+                reviewRepository.save(review);
+            } else {
+                return "connect fail";
+            }
+        } else {
+            return "connect fail";
+        }
+
+        return "connect";
+    }
+
     private void planUpdateReviewToNull(Plan plan, String reviewId) {
         if (plan != null) {
             /*plan의 review 정보 삭제*/

--- a/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/ReviewService.java
+++ b/trizzle-backend/src/main/java/trizzle/trizzlebackend/service/ReviewService.java
@@ -251,6 +251,35 @@ public class ReviewService {
         return "connect";
     }
 
+    public String reviewDisconnect(Plan plan, String reviewId, String accountId) {
+        /*review 연동해제 된 것 plan에 반영*/
+        Plan existingPlan = planRepository.findByIdAndAccountId(plan.getId(), accountId);
+        if (existingPlan != null) {
+            existingPlan.setContent(plan.getContent());
+            planRepository.save(existingPlan);
+
+            /* postId null 아니라면(post연동된 일정이라면) post의 해당 review null로*/
+            if (plan.getPostId() != null) {
+                Post post = postRepository.findByIdAndAccountId(plan.getPostId(), accountId);
+                post.setPlan(existingPlan);
+                postRepository.save(post);
+            }
+
+            /* review에 planId null로 (연동해제)*/
+            Review review = reviewRepository.findByIdAndAccountId(reviewId, accountId);
+            if (review != null) {
+                review.setPlanId(null);
+                reviewRepository.save(review);
+            } else {
+                return "disconnect fail";
+            }
+        } else {
+            return "disconnect fail";
+        }
+
+        return "disconnect";
+        }
+
     private void planUpdateReviewToNull(Plan plan, String reviewId) {
         if (plan != null) {
             /*plan의 review 정보 삭제*/


### PR DESCRIPTION
## 삭제 오류 수정
- 일정 게시글 삭제: 
  - 게시글id에 해당하는 좋아요, 북마크 삭제, 댓글 삭제(댓글 좋아요도 다같이)
  - plan의 review연동기록 삭제, 
  - review의 planId 사게
- 리뷰 삭제:
  - 일정or일정 게시글에서 연동 된것 삭제(review정보)
  - 게시글id에 해당하는 좋아요, 북마크 삭제, 댓글 삭제(댓글 좋아요도 다같이)

## 연동 및 연동해제 API
- plan에 review연동 및 해제 api 추가